### PR TITLE
feat: make PORT and BASE_URL configurable via environment variables

### DIFF
--- a/packages/shared/src/constants/defaults.ts
+++ b/packages/shared/src/constants/defaults.ts
@@ -4,7 +4,7 @@ export const DEFAULTS = {
 	PORT,
 	ENV: ".env",
 	VAR_NAME: "DATABASE_URL",
-	BASE_URL: process.env.BASE_URL ?? `http://localhost:${PORT}`,
+	BASE_URL: process.env.BASE_URL || `http://localhost:${PORT}`,
 	PROXY_URL:
 		process.env.NODE_ENV === "development"
 			? "http://localhost:8787"

--- a/packages/shared/src/constants/defaults.ts
+++ b/packages/shared/src/constants/defaults.ts
@@ -1,8 +1,10 @@
+const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3333;
+
 export const DEFAULTS = {
-	PORT: 3333,
+	PORT,
 	ENV: ".env",
 	VAR_NAME: "DATABASE_URL",
-	BASE_URL: "http://localhost:3333",
+	BASE_URL: process.env.BASE_URL ?? `http://localhost:${PORT}`,
 	PROXY_URL:
 		process.env.NODE_ENV === "development"
 			? "http://localhost:8787"


### PR DESCRIPTION
## Summary
- Made `PORT` configurable via `process.env.PORT` with a fallback to `3333`.
- Made `BASE_URL` configurable via `process.env.BASE_URL` with a fallback to `http://localhost:${PORT}`.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-126df6bf043248c79c8b4810af9f6662)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Environment variables now control the application port and base URL for flexible deployments.
  * When environment variables are not provided, the app falls back to the previous local defaults to preserve local development behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->