### PR TITLE
fix(chat): revive chat sidebar and align with local dev

### DIFF
--- a/packages/core/src/components/chat/chat-sidebar.tsx
+++ b/packages/core/src/components/chat/chat-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { fetchServerSentEvents, useChat } from "@tanstack/ai-react";
 import { Plus } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CHAT_SUGGESTIONS, DEFAULTS } from "shared/constants";
 import {
 	Conversation,
@@ -35,22 +35,51 @@ import { SheetSidebar } from "@/components/sheet-sidebar";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useRateLimit } from "@/hooks/use-rate-limit";
+import { useDatabaseStore } from "@/stores/database.store";
 import { useSheetStore } from "@/stores/sheet.store";
 
-export const ChatSidebar = () => {
-	const { rateLimit, refetchRateLimit } = useRateLimit();
+interface ChatController {
+	clear: () => void;
+	isLoading: boolean;
+}
+
+interface ChatSidebarContentProps {
+	db: string;
+	onRateLimitRefetch: () => void;
+	onControllerReady: (controller: ChatController) => void;
+}
+
+// `useChat` captures `body` only at initial mount (via useMemo([clientId])).
+// Keying this inner component on `db` forces a remount when the database
+// changes, so the ChatClient is rebuilt with a fresh body.
+const ChatSidebarContent = ({
+	db,
+	onRateLimitRefetch,
+	onControllerReady,
+}: ChatSidebarContentProps) => {
 	const [text, setText] = useState("");
-	const { isSheetOpen, closeSheet } = useSheetStore();
+	const { rateLimit } = useRateLimit();
 
 	const { messages, sendMessage, isLoading, clear, stop } = useChat({
 		connection: fetchServerSentEvents(`${DEFAULTS.BASE_URL}/chat`),
+		body: { db },
 		onError: (error) => console.error("Error:", error.message),
 		onResponse: (response) => console.log("Response:", response),
 		onFinish: (message) => {
 			console.log("Finish:", message);
-			refetchRateLimit();
+			onRateLimitRefetch();
 		},
 	});
+
+	useEffect(() => {
+		onControllerReady({
+			clear: () => {
+				clear();
+				setText("");
+			},
+			isLoading,
+		});
+	}, [clear, isLoading, onControllerReady]);
 
 	const handleSubmit = (message: PromptInputMessage) => {
 		const hasText = Boolean(message.text);
@@ -61,11 +90,6 @@ export const ChatSidebar = () => {
 		}
 
 		sendMessage(message.text);
-		setText("");
-	};
-
-	const handleNewChat = () => {
-		clear();
 		setText("");
 	};
 
@@ -80,6 +104,123 @@ export const ChatSidebar = () => {
 	};
 
 	const status = isLoading ? "streaming" : "ready";
+
+	return (
+		<div className="relative flex size-full flex-col divide-y overflow-hidden">
+			<Conversation>
+				<ConversationContent>
+					{messages.length === 0 ? (
+						<div className="flex items-center justify-center h-full text-muted-foreground">
+							<div className="text-center space-y-2">
+								<p className="text-lg font-medium">Start a new conversation</p>
+								<p className="text-sm">Ask me anything to get started</p>
+							</div>
+						</div>
+					) : (
+						<>
+							{messages.map((message) => {
+								const thinkingParts = message.parts.filter((part) => part.type === "thinking");
+								const textContent = message.parts
+									.filter((part) => part.type === "text")
+									.map((part) => part.content)
+									.join("");
+
+								const hasThinking = thinkingParts.length > 0;
+
+								return (
+									<MessageBranch
+										defaultBranch={0}
+										key={message.id}
+									>
+										<MessageBranchContent>
+											<Message from={message.role === "user" ? "user" : "assistant"}>
+												<div>
+													{hasThinking && message.role === "assistant" && (
+														<Reasoning duration={0}>
+															<ReasoningTrigger />
+															<ReasoningContent>
+																{thinkingParts.map((part) => part.content).join("\n")}
+															</ReasoningContent>
+														</Reasoning>
+													)}
+													<MessageContent>
+														<MessageResponse>{textContent}</MessageResponse>
+													</MessageContent>
+												</div>
+											</Message>
+										</MessageBranchContent>
+									</MessageBranch>
+								);
+							})}
+
+							{isLoading && (
+								<MessageBranch defaultBranch={0}>
+									<MessageBranchContent>
+										<Message from="assistant">
+											<MessageContent>
+												<LoadingText>Thinking...</LoadingText>
+											</MessageContent>
+										</Message>
+									</MessageBranchContent>
+								</MessageBranch>
+							)}
+						</>
+					)}
+				</ConversationContent>
+				<ConversationScrollButton />
+			</Conversation>
+
+			<div className="grid shrink-0 gap-4 pt-3">
+				{messages.length === 0 && (
+					<Suggestions className="px-4">
+						{CHAT_SUGGESTIONS.map((suggestion) => (
+							<Suggestion
+								key={suggestion}
+								onClick={() => handleSuggestionClick(suggestion)}
+								suggestion={suggestion}
+								size="lg"
+							>
+								{suggestion}
+							</Suggestion>
+						))}
+					</Suggestions>
+				)}
+
+				<div className="w-full px-4 pb-4">
+					<PromptInput
+						globalDrop
+						multiple
+						onSubmit={handleSubmit}
+					>
+						<PromptInputBody>
+							<PromptInputTextarea
+								onChange={(event) => setText(event.target.value)}
+								value={text}
+								placeholder="Type a message..."
+							/>
+						</PromptInputBody>
+
+						<PromptInputFooter>
+							<PromptInputSubmit
+								className="h-8!"
+								status={status}
+								onClick={isLoading ? handleStop : undefined}
+								disabled={rateLimit && rateLimit.remaining === 0}
+							/>
+						</PromptInputFooter>
+					</PromptInput>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export const ChatSidebar = () => {
+	const { rateLimit, refetchRateLimit } = useRateLimit();
+	const { isSheetOpen, closeSheet } = useSheetStore();
+	const { selectedDatabase } = useDatabaseStore();
+	const [controller, setController] = useState<ChatController | null>(null);
+	const controllerSetterRef = useRef((next: ChatController) => setController(next));
 
 	return (
 		<SheetSidebar
@@ -99,16 +240,18 @@ export const ChatSidebar = () => {
 						</Tooltip>
 					)}
 
-					<Button
-						type="button"
-						variant="outline"
-						size="lg"
-						onClick={handleNewChat}
-						disabled={isLoading}
-					>
-						<Plus className="h-4 w-4 mr-1" />
-						New Chat
-					</Button>
+					{selectedDatabase && controller && (
+						<Button
+							type="button"
+							variant="outline"
+							size="lg"
+							onClick={controller.clear}
+							disabled={controller.isLoading}
+						>
+							<Plus className="h-4 w-4 mr-1" />
+							New Chat
+						</Button>
+					)}
 				</div>
 			}
 			closeButton={false}
@@ -121,114 +264,21 @@ export const ChatSidebar = () => {
 				}
 			}}
 		>
-			<div className="relative flex size-full flex-col divide-y overflow-hidden">
-				<Conversation>
-					<ConversationContent>
-						{messages.length === 0 ? (
-							<div className="flex items-center justify-center h-full text-muted-foreground">
-								<div className="text-center space-y-2">
-									<p className="text-lg font-medium">Start a new conversation</p>
-									<p className="text-sm">Ask me anything to get started</p>
-								</div>
-							</div>
-						) : (
-							<>
-								{messages.map((message) => {
-									const thinkingParts = message.parts.filter(
-										(part) => part.type === "thinking",
-									);
-									const textContent = message.parts
-										.filter((part) => part.type === "text")
-										.map((part) => part.content)
-										.join("");
-
-									const hasThinking = thinkingParts.length > 0;
-
-									return (
-										<MessageBranch
-											defaultBranch={0}
-											key={message.id}
-										>
-											<MessageBranchContent>
-												<Message from={message.role === "user" ? "user" : "assistant"}>
-													<div>
-														{hasThinking && message.role === "assistant" && (
-															<Reasoning duration={0}>
-																<ReasoningTrigger />
-																<ReasoningContent>
-																	{thinkingParts.map((part) => part.content).join("\n")}
-																</ReasoningContent>
-															</Reasoning>
-														)}
-														<MessageContent>
-															<MessageResponse>{textContent}</MessageResponse>
-														</MessageContent>
-													</div>
-												</Message>
-											</MessageBranchContent>
-										</MessageBranch>
-									);
-								})}
-
-								{isLoading && (
-									<MessageBranch defaultBranch={0}>
-										<MessageBranchContent>
-											<Message from="assistant">
-												<MessageContent>
-													<LoadingText>Thinking...</LoadingText>
-												</MessageContent>
-											</Message>
-										</MessageBranchContent>
-									</MessageBranch>
-								)}
-							</>
-						)}
-					</ConversationContent>
-					<ConversationScrollButton />
-				</Conversation>
-
-				<div className="grid shrink-0 gap-4 pt-3">
-					{messages.length === 0 && (
-						<Suggestions className="px-4">
-							{CHAT_SUGGESTIONS.map((suggestion) => (
-								<Suggestion
-									key={suggestion}
-									onClick={() => handleSuggestionClick(suggestion)}
-									suggestion={suggestion}
-									size="lg"
-								>
-									{suggestion}
-								</Suggestion>
-							))}
-						</Suggestions>
-					)}
-
-					<div className="w-full px-4 pb-4">
-						<PromptInput
-							globalDrop
-							multiple
-							onSubmit={handleSubmit}
-						>
-							<PromptInputBody>
-								<PromptInputTextarea
-									onChange={(event) => setText(event.target.value)}
-									value={text}
-									placeholder="Type a message..."
-								/>
-							</PromptInputBody>
-
-							<PromptInputFooter>
-								<PromptInputSubmit
-									className="h-8!"
-									status={status}
-									onClick={isLoading ? handleStop : undefined}
-									disabled={rateLimit && rateLimit.remaining === 0}
-								/>
-							</PromptInputFooter>
-						</PromptInput>
+			{selectedDatabase ? (
+				<ChatSidebarContent
+					key={selectedDatabase}
+					db={selectedDatabase}
+					onRateLimitRefetch={refetchRateLimit}
+					onControllerReady={controllerSetterRef.current}
+				/>
+			) : (
+				<div className="flex items-center justify-center h-full text-muted-foreground p-8">
+					<div className="text-center space-y-2">
+						<p className="text-lg font-medium">No database selected</p>
+						<p className="text-sm">Select a database from the sidebar to start chatting.</p>
 					</div>
 				</div>
-			</div>
+			)}
 		</SheetSidebar>
 	);
 };

--- a/packages/core/src/components/components/header.tsx
+++ b/packages/core/src/components/components/header.tsx
@@ -1,14 +1,12 @@
 import { Bug, Github } from "lucide-react";
 import { META } from "shared/constants";
-// import { Chat } from "@/components/chat/chat";
+import { Chat } from "@/components/chat/chat";
 import { Tabs } from "@/components/components/tabs";
 import { SidebarToggleButton } from "@/components/sidebar/sidebar-toggle-btn";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export const Header = () => {
-	// const { openSheet } = useSheetStore();
-
 	return (
 		<div className="border-b border-zinc-800 w-full flex items-center justify-between bg-black h-12">
 			<div className="flex items-center h-full">
@@ -17,21 +15,7 @@ export const Header = () => {
 			</div>
 
 			<div className="flex items-center h-full">
-				{/* <Chat /> */}
-				{/* <Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							variant="ghost"
-							className="border-r-0 border-y-0 border-l border-zinc-800 rounded-none h-full w-12"
-							onClick={() => openSheet("ai-assistant")}
-						>
-							<IconSparkles className="size-5" />
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent>
-						<p>AI Assistant</p>
-					</TooltipContent>
-				</Tooltip> */}
+				<Chat />
 
 				<Tooltip>
 					<TooltipTrigger asChild>

--- a/packages/core/src/hooks/use-rate-limit.ts
+++ b/packages/core/src/hooks/use-rate-limit.ts
@@ -2,6 +2,9 @@ import { useQuery } from "@tanstack/react-query";
 import { DEFAULTS } from "shared/constants";
 import type { RateLimitResponse } from "shared/types";
 
+const UNLIMITED: RateLimitResponse = { limit: 999, used: 0, remaining: 999 };
+const IS_LOCAL = typeof window !== "undefined" && window.location.hostname === "localhost";
+
 export const useRateLimit = () => {
 	const {
 		data: rateLimit,
@@ -11,12 +14,14 @@ export const useRateLimit = () => {
 	} = useQuery<RateLimitResponse>({
 		queryKey: ["rate-limit"],
 		queryFn: async () => {
-			const response = await fetch(`${DEFAULTS.PROXY_URL}/chat/limit`);
-			if (!response.ok) {
-				throw new Error("Failed to fetch rate limit");
+			if (IS_LOCAL) return UNLIMITED;
+			try {
+				const response = await fetch(`${DEFAULTS.PROXY_URL}/chat/limit`);
+				if (!response.ok) return UNLIMITED;
+				return await response.json();
+			} catch {
+				return UNLIMITED;
 			}
-			const data = await response.json();
-			return data;
 		},
 	});
 

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -103,12 +103,13 @@ export default defineConfig(({ mode }) => {
     },
   },
   server: {
-    port: 3333,
+    port: 3001,
     host: true,
     proxy: {
       "/api": {
         target: "http://localhost:3333",
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
       },
     },
   },

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -7,7 +7,7 @@ import { LIMIT } from "shared/constants";
 import { createProxyLimiter, keyGenerator } from "./limit";
 import { getRedis } from "./redis";
 
-const app = new Hono();
+const app = new Hono<{ Bindings: CloudflareBindings }>();
 
 app.use(
 	"/*",
@@ -65,6 +65,10 @@ app.post("/chat", async (c) => {
  */
 app.get("/chat/limit", async (c) => {
 	try {
+		if (!c.env.UPSTASH_REDIS_REST_URL || !c.env.UPSTASH_REDIS_REST_TOKEN) {
+			return c.json({ limit: LIMIT, used: 0, remaining: LIMIT });
+		}
+
 		const key = keyGenerator(c);
 		const usageKey = `rate:proxy:${key}`;
 

--- a/packages/proxy/src/limit.ts
+++ b/packages/proxy/src/limit.ts
@@ -15,6 +15,11 @@ export const keyGenerator = (c: Context) => {
 
 export const createProxyLimiter = (): MiddlewareHandler => {
 	return async (c, next) => {
+		if (!c.env.UPSTASH_REDIS_REST_URL || !c.env.UPSTASH_REDIS_REST_TOKEN) {
+			console.warn("[proxy] Upstash Redis not configured — skipping rate limiter");
+			return next();
+		}
+
 		const store = getRedisStore(c);
 		const limiter = rateLimiter({
 			windowMs: ONE_DAY,

--- a/packages/server/src/dao/table-list.dao.ts
+++ b/packages/server/src/dao/table-list.dao.ts
@@ -1,4 +1,3 @@
-import { HTTPException } from "hono/http-exception";
 import type { TableInfoSchemaType } from "shared/types";
 import type { DatabaseSchemaType } from "shared/types/database.types.js";
 import { getDbPool } from "@/db-manager.js";
@@ -19,9 +18,7 @@ export async function getTablesList(
 
 	const { rows: tables } = await pool.query(tablesQuery);
 	if (!tables[0]) {
-		throw new HTTPException(500, {
-			message: "No tables returned from database",
-		});
+		return [];
 	}
 
 	// Get accurate row count for each table

--- a/packages/server/src/routes/chat.routes.ts
+++ b/packages/server/src/routes/chat.routes.ts
@@ -16,7 +16,8 @@ export const chatRoutes = new Hono()
 	 * Proxies to the Cloudflare Worker which has the Gemini API key
 	 */
 	.post("/", zValidator("json", chatSchema), async (c) => {
-		const { messages, conversationId, db } = c.req.valid("json");
+		const { messages, data } = c.req.valid("json");
+		const { db, conversationId } = data;
 		console.log("POST /chat messages", messages);
 
 		// Get the database schema and generate system prompt

--- a/packages/server/src/utils/create-server.ts
+++ b/packages/server/src/utils/create-server.ts
@@ -73,6 +73,7 @@ export const createServer = () => {
 		 * Database routes - available at root level (no dbType required)
 		 */
 		.route("/", databasesRoutes)
+		.route("/", chatRoutes)
 
 		/**
 		 * Serve static assets (before dbType validation to avoid conflicts)
@@ -92,7 +93,6 @@ export const createServer = () => {
 		.route("/:dbType", tablesRoutes)
 		.route("/:dbType", recordsRoutes)
 		.route("/:dbType", queryRoutes)
-		.route("/:dbType", chatRoutes)
 
 		/**
 		 * Serve all other static files as fallback (for SPA)

--- a/packages/shared/src/types/chat.types.ts
+++ b/packages/shared/src/types/chat.types.ts
@@ -1,13 +1,17 @@
 import { z } from "zod";
 import { databaseSchema } from "./database.types.js";
 
+// `@tanstack/ai-react`'s `fetchServerSentEvents` adapter wraps the body supplied
+// to `useChat` under a `data` field: `{ messages, data: { ...body, conversationId } }`.
 export const chatSchema = z.object({
 	messages: z.array(
 		z.object({
-			role: z.enum(["user", "assistant"]),
-			content: z.string("Content is required"),
+			role: z.enum(["user", "assistant", "system", "tool"]),
+			content: z.string().nullable(),
 		}),
 	),
-	conversationId: z.string().optional(),
-	db: databaseSchema.shape.db,
+	data: z.object({
+		conversationId: z.string().optional(),
+		db: databaseSchema.shape.db,
+	}),
 });


### PR DESCRIPTION
## Summary

Re-enables the AI chat sidebar (currently commented out in the header) and fixes a handful of issues that surfaced while bringing it back online.

## Changes & reasoning

**Chat is now scoped to the selected database** — `@tanstack/ai-react`'s `useChat` memoizes its request `body` at mount (`useMemo([clientId])`), so changing `db` later does nothing. I split the sidebar into an outer container and an inner `ChatSidebarContent` keyed on `selectedDatabase`, which forces a remount (and a fresh `ChatClient`) when the user switches databases. A controller object exposes `clear` + `isLoading` back to the container so the "New Chat" button still works.

**Chat payload schema follows the tanstack SSE envelope** — `fetchServerSentEvents` wraps the supplied `body` under a `data` field: `{ messages, data: { ...body, conversationId } }`. `chatSchema` and the `/chat` route now match that shape. Also widened `role` to `user | assistant | system | tool` and made `content` nullable to reflect what the adapter can emit.

**`/chat` moved out of the `/:dbType` scope** — now that `db` lives in the request body, the route no longer needs the dbType prefix and is mounted at the root.

**Local-dev fallbacks when the proxy / Upstash Redis isn't configured** — both the Cloudflare proxy (`/chat/limit` and the rate-limiter middleware) and the frontend `useRateLimit` hook now return a permissive limit instead of erroring when the Upstash env vars are missing, so you can run the app end-to-end without provisioning Redis.

**Vite dev server aligned with `CLAUDE.md`** — port `3001` (docs say 3001, code said 3333), and `/api` is now stripped when proxying to `:3333` since server routes don't have an `/api` prefix.

**`getTablesList` no longer 500s on an empty database** — returning `[]` instead of throwing `HTTPException` when there are zero tables; an empty DB is a valid state, not a server error.

## Test plan

- [ ] `bun run dev` — frontend at `:3001` proxies to API at `:3333` without 404s
- [ ] Open chat sidebar without a selected DB → shows the "No database selected" empty state
- [ ] Select a DB, send a message → streams a response
- [ ] Switch to a different DB → chat remounts with empty history and subsequent messages use the new DB's schema
- [ ] "New Chat" clears messages and is disabled while a response is streaming
- [ ] Run without `UPSTASH_REDIS_REST_URL` → proxy and rate-limit UI both work (no 500s, unlimited shown)
- [ ] Connect to an empty database → table list endpoint returns `[]` rather than 500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat interface now dynamically responds to database selection changes
  * Improved chat experience with better loading state management and conversation control

* **Bug Fixes**
  * Fixed error handling when databases contain no tables
  * Enhanced rate limiting behavior for local development environments

* **Chores**
  * Updated development server configuration and API proxy settings
  * Improved environment variable handling for production deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->