### PR TITLE
fix(sqlite): resolve CodeRabbit PR#189 review issues

### DIFF
--- a/packages/server/src/adapters/sqlite/sqlite.adapter.ts
+++ b/packages/server/src/adapters/sqlite/sqlite.adapter.ts
@@ -268,6 +268,7 @@ export class SqliteAdapter extends BaseAdapter {
 			}
 
 			const sortClause = buildSortClause(Array.isArray(sort) ? sort : sort, order);
+			const pkTieBreakerCols = pkColumns.filter((pk) => !sortColumns.includes(pk));
 			let effectiveSortClause = sortClause;
 
 			if (direction === "desc") {
@@ -276,11 +277,17 @@ export class SqliteAdapter extends BaseAdapter {
 						.replace(/\bASC\b/gi, "TEMP_DESC")
 						.replace(/\bDESC\b/gi, "ASC")
 						.replace(/TEMP_DESC/g, "DESC");
+					if (pkTieBreakerCols.length) {
+						const tbDir = effectiveSortDirection === "asc" ? "DESC" : "ASC";
+						effectiveSortClause += `, ${pkTieBreakerCols.map((col) => `"${col}" ${tbDir}`).join(", ")}`;
+					}
 				} else {
 					effectiveSortClause = `ORDER BY ${cursorColumns.map((col) => `"${col}" ${effectiveSortDirection === "asc" ? "DESC" : "ASC"}`).join(", ")}`;
 				}
 			} else if (!sortClause) {
 				effectiveSortClause = `ORDER BY ${cursorColumns.map((col) => `"${col}" ${effectiveSortDirection.toUpperCase()}`).join(", ")}`;
+			} else if (pkTieBreakerCols.length) {
+				effectiveSortClause += `, ${pkTieBreakerCols.map((col) => `"${col}" ${effectiveSortDirection.toUpperCase()}`).join(", ")}`;
 			}
 
 			const countRow = sqliteDb
@@ -350,46 +357,59 @@ export class SqliteAdapter extends BaseAdapter {
 	// =========================================================
 
 	async getDatabasesList(): Promise<DatabaseInfoSchemaType[]> {
-		const sqliteDb = getSqliteDb();
-		const rows = sqliteDb.prepare("PRAGMA database_list").all() as Array<{
-			seq: number;
-			name: string;
-			file: string;
-		}>;
+		try {
+			const sqliteDb = getSqliteDb();
+			const rows = sqliteDb.prepare("PRAGMA database_list").all() as Array<{
+				seq: number;
+				name: string;
+				file: string;
+			}>;
 
-		if (!rows.length)
-			throw new HTTPException(500, { message: "No databases returned from SQLite" });
+			if (!rows.length)
+				throw new HTTPException(500, { message: "No databases returned from SQLite" });
 
-		return rows.map((row) => ({
-			name: row.name,
-			size: this.getFileSize(row.file),
-			owner: "",
-			encoding: "UTF-8",
-		}));
+			return rows.map((row) => ({
+				name: row.name,
+				size: this.getFileSize(row.file),
+				owner: "",
+				encoding: "UTF-8",
+			}));
+		} catch (e) {
+			if (e instanceof HTTPException) throw e;
+			throw this.wrapError(e);
+		}
 	}
 
 	async getCurrentDatabase(): Promise<DatabaseSchemaType> {
-		const sqliteDb = getSqliteDb();
-		const rows = sqliteDb.prepare("PRAGMA database_list").all() as Array<{ name: string }>;
-		const main = rows.find((r) => r.name === "main");
-		return { db: main?.name ?? "main" };
+		try {
+			const sqliteDb = getSqliteDb();
+			const rows = sqliteDb.prepare("PRAGMA database_list").all() as Array<{ name: string }>;
+			const main = rows.find((r) => r.name === "main");
+			return { db: main?.name ?? "main" };
+		} catch (e) {
+			throw this.wrapError(e);
+		}
 	}
 
 	async getDatabaseConnectionInfo(): Promise<ConnectionInfoSchemaType> {
-		const sqliteDb = getSqliteDb();
-		const versionRow = sqliteDb.prepare("SELECT sqlite_version() as version").get() as {
-			version: string;
-		};
+		try {
+			const sqliteDb = getSqliteDb();
+			const versionRow = sqliteDb.prepare("SELECT sqlite_version() as version").get() as {
+				version: string;
+			};
 
-		return {
-			host: null,
-			port: null,
-			user: "",
-			database: "main",
-			version: `SQLite ${versionRow.version}`,
-			active_connections: 1,
-			max_connections: 1,
-		};
+			return {
+				host: null,
+				port: null,
+				user: "",
+				database: "main",
+				version: `SQLite ${versionRow.version}`,
+				active_connections: 1,
+				max_connections: 1,
+			};
+		} catch (e) {
+			throw this.wrapError(e);
+		}
 	}
 
 	// =========================================================
@@ -397,19 +417,23 @@ export class SqliteAdapter extends BaseAdapter {
 	// =========================================================
 
 	async getTablesList(_db: DatabaseSchemaType["db"]): Promise<TableInfoSchemaType[]> {
-		const sqliteDb = getSqliteDb();
-		const tables = sqliteDb
-			.prepare(
-				`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
-			)
-			.all() as Array<{ name: string }>;
+		try {
+			const sqliteDb = getSqliteDb();
+			const tables = sqliteDb
+				.prepare(
+					`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
+				)
+				.all() as Array<{ name: string }>;
 
-		return tables.map((t) => {
-			const countRow = sqliteDb.prepare(`SELECT COUNT(*) as count FROM "${t.name}"`).get() as {
-				count: number;
-			};
-			return { tableName: t.name, rowCount: countRow?.count ?? 0 };
-		});
+			return tables.map((t) => {
+				const countRow = sqliteDb
+					.prepare(`SELECT COUNT(*) as count FROM "${t.name}"`)
+					.get() as { count: number };
+				return { tableName: t.name, rowCount: countRow?.count ?? 0 };
+			});
+		} catch (e) {
+			throw this.wrapError(e);
+		}
 	}
 
 	async createTable({
@@ -499,13 +523,18 @@ export class SqliteAdapter extends BaseAdapter {
 		tableName: string;
 		db: DatabaseSchemaType["db"];
 	}): Promise<string> {
-		const sqliteDb = getSqliteDb();
-		const row = sqliteDb
-			.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`)
-			.get(tableName) as { sql: string } | undefined;
-		if (!row) throw new HTTPException(404, { message: `Table "${tableName}" does not exist` });
-		void db;
-		return row.sql;
+		try {
+			const sqliteDb = getSqliteDb();
+			const row = sqliteDb
+				.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`)
+				.get(tableName) as { sql: string } | undefined;
+			if (!row) throw new HTTPException(404, { message: `Table "${tableName}" does not exist` });
+			void db;
+			return row.sql;
+		} catch (e) {
+			if (e instanceof HTTPException) throw e;
+			throw this.wrapError(e);
+		}
 	}
 
 	// =========================================================
@@ -519,41 +548,46 @@ export class SqliteAdapter extends BaseAdapter {
 		tableName: string;
 		db: DatabaseSchemaType["db"];
 	}): Promise<ColumnInfoSchemaType[]> {
-		const sqliteDb = getSqliteDb();
+		try {
+			const sqliteDb = getSqliteDb();
 
-		const tableRow = sqliteDb
-			.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
-			.get(tableName);
-		if (!tableRow)
-			throw new HTTPException(404, { message: `Table "${tableName}" does not exist` });
+			const tableRow = sqliteDb
+				.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+				.get(tableName);
+			if (!tableRow)
+				throw new HTTPException(404, { message: `Table "${tableName}" does not exist` });
 
-		const columns = sqliteDb
-			.prepare(`PRAGMA table_info("${tableName}")`)
-			.all() as TableInfoRow[];
-		const fks = sqliteDb.prepare(`PRAGMA foreign_key_list("${tableName}")`).all() as FkRow[];
+			const columns = sqliteDb
+				.prepare(`PRAGMA table_info("${tableName}")`)
+				.all() as TableInfoRow[];
+			const fks = sqliteDb.prepare(`PRAGMA foreign_key_list("${tableName}")`).all() as FkRow[];
 
-		const fkMap = new Map<string, FkRow>();
-		for (const fk of fks) {
-			fkMap.set(fk.from, fk);
+			const fkMap = new Map<string, FkRow>();
+			for (const fk of fks) {
+				fkMap.set(fk.from, fk);
+			}
+
+			void db;
+			return columns.map((col) => {
+				const fk = fkMap.get(col.name);
+				const nativeType = col.type.toLowerCase();
+				return {
+					columnName: col.name,
+					dataType: mapSqliteToDataType(nativeType),
+					dataTypeLabel: standardizeSqliteDataTypeLabel(nativeType),
+					isNullable: col.notnull === 0 && col.pk === 0,
+					columnDefault: col.dflt_value,
+					isPrimaryKey: col.pk > 0,
+					isForeignKey: fkMap.has(col.name),
+					referencedTable: fk?.table ?? null,
+					referencedColumn: fk?.to ?? null,
+					enumValues: null,
+				};
+			});
+		} catch (e) {
+			if (e instanceof HTTPException) throw e;
+			throw this.wrapError(e);
 		}
-
-		void db;
-		return columns.map((col) => {
-			const fk = fkMap.get(col.name);
-			const nativeType = col.type.toLowerCase();
-			return {
-				columnName: col.name,
-				dataType: mapSqliteToDataType(nativeType),
-				dataTypeLabel: standardizeSqliteDataTypeLabel(nativeType),
-				isNullable: col.notnull === 0 && col.pk === 0,
-				columnDefault: col.dflt_value,
-				isPrimaryKey: col.pk > 0,
-				isForeignKey: fkMap.has(col.name),
-				referencedTable: fk?.table ?? null,
-				referencedColumn: fk?.to ?? null,
-				enumValues: null,
-			};
-		});
 	}
 
 	async addColumn(params: AddColumnParamsSchemaType): Promise<void> {
@@ -677,6 +711,15 @@ export class SqliteAdapter extends BaseAdapter {
 		const colNames = colInfo.map((c) => `"${c.name}"`).join(", ");
 		const tempName = `${tableName}_alter_${Date.now()}`;
 
+		const existingIndexes = sqliteDb
+			.prepare(
+				`SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=? AND sql IS NOT NULL`,
+			)
+			.all(tableName) as Array<{ sql: string }>;
+		const existingTriggers = sqliteDb
+			.prepare(`SELECT sql FROM sqlite_master WHERE type='trigger' AND tbl_name=?`)
+			.all(tableName) as Array<{ sql: string }>;
+
 		sqliteDb.pragma("foreign_keys = OFF");
 		const doAlter = sqliteDb.transaction(() => {
 			sqliteDb
@@ -693,6 +736,12 @@ export class SqliteAdapter extends BaseAdapter {
 
 		try {
 			doAlter();
+			for (const { sql } of existingIndexes) {
+				sqliteDb.prepare(sql).run();
+			}
+			for (const { sql } of existingTriggers) {
+				sqliteDb.prepare(sql).run();
+			}
 		} catch (e) {
 			if (e instanceof HTTPException) throw e;
 			throw this.wrapError(e);
@@ -755,7 +804,9 @@ export class SqliteAdapter extends BaseAdapter {
 		if (!columns.length)
 			throw new HTTPException(400, { message: "No data provided for insert" });
 
-		const values = Object.values(data);
+		const values = Object.values(data).map((v) =>
+			v !== null && typeof v === "object" ? JSON.stringify(v) : v,
+		);
 		const colNames = columns.map((c) => `"${c}"`).join(", ");
 		const placeholders = columns.map(() => "?").join(", ");
 
@@ -933,7 +984,10 @@ export class SqliteAdapter extends BaseAdapter {
 		const doInsert = sqliteDb.transaction((recs: typeof records) => {
 			let count = 0;
 			for (const record of recs) {
-				const values = columns.map((col) => record[col]);
+				const values = columns.map((col) => {
+					const v = record[col];
+					return v !== null && typeof v === "object" ? JSON.stringify(v) : v;
+				});
 				// biome-ignore lint/suspicious/noExplicitAny: better-sqlite3 spread
 				stmt.run(...(values as any[]));
 				count++;

--- a/packages/server/src/adapters/sqlite/sqlite.adapter.ts
+++ b/packages/server/src/adapters/sqlite/sqlite.adapter.ts
@@ -528,7 +528,8 @@ export class SqliteAdapter extends BaseAdapter {
 			const row = sqliteDb
 				.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`)
 				.get(tableName) as { sql: string } | undefined;
-			if (!row) throw new HTTPException(404, { message: `Table "${tableName}" does not exist` });
+			if (!row)
+				throw new HTTPException(404, { message: `Table "${tableName}" does not exist` });
 			void db;
 			return row.sql;
 		} catch (e) {

--- a/packages/server/src/db-manager.ts
+++ b/packages/server/src/db-manager.ts
@@ -330,6 +330,10 @@ class DatabaseManager {
 	 * Close a specific database pool by connection string (both types)
 	 */
 	async closePool(connectionString: string): Promise<void> {
+		if (this.baseConfig?.dbType === "sqlite" && connectionString === this.baseConfig.url) {
+			this.closeSqliteDb();
+			return;
+		}
 		await this.closePgPool(connectionString);
 		await this.closeMysqlPool(connectionString);
 		await this.closeMssqlPool(connectionString);
@@ -339,6 +343,10 @@ class DatabaseManager {
 	 * Close a specific database pool by database name
 	 */
 	async closePoolByDatabase(database: string): Promise<void> {
+		if (this.baseConfig?.dbType === "sqlite") {
+			this.closeSqliteDb();
+			return;
+		}
 		const connectionString = this.buildConnectionString(database);
 		await this.closePool(connectionString);
 	}

--- a/packages/shared/src/types/column.type.ts
+++ b/packages/shared/src/types/column.type.ts
@@ -628,14 +628,15 @@ export function standardizeSqliteDataTypeLabel(sqliteType: string): Standardized
 	const normalized = sqliteType?.toLowerCase().trim() || "";
 
 	if (normalized === "integer" || normalized === "int") return StandardizedDataType.int;
-	if (normalized === "bigint") return StandardizedDataType.bigint;
-	if (normalized === "smallint") return StandardizedDataType.smallint;
-	if (normalized === "tinyint") return StandardizedDataType.tinyint;
-	if (normalized === "mediumint") return StandardizedDataType.mediumint;
+	if (normalized === "bigint" || normalized.startsWith("bigint(")) return StandardizedDataType.bigint;
+	if (normalized === "smallint" || normalized.startsWith("smallint(")) return StandardizedDataType.smallint;
+	if (normalized === "tinyint" || normalized.startsWith("tinyint(")) return StandardizedDataType.tinyint;
+	if (normalized === "mediumint" || normalized.startsWith("mediumint(")) return StandardizedDataType.mediumint;
 	if (normalized.includes("int")) return StandardizedDataType.int;
 
-	if (normalized === "real" || normalized === "float") return StandardizedDataType.float;
-	if (normalized === "double" || normalized === "double precision")
+	if (normalized === "real" || normalized === "float" || normalized.startsWith("float("))
+		return StandardizedDataType.float;
+	if (normalized === "double" || normalized === "double precision" || normalized.startsWith("double("))
 		return StandardizedDataType.double;
 
 	if (

--- a/packages/shared/src/types/column.type.ts
+++ b/packages/shared/src/types/column.type.ts
@@ -628,15 +628,23 @@ export function standardizeSqliteDataTypeLabel(sqliteType: string): Standardized
 	const normalized = sqliteType?.toLowerCase().trim() || "";
 
 	if (normalized === "integer" || normalized === "int") return StandardizedDataType.int;
-	if (normalized === "bigint" || normalized.startsWith("bigint(")) return StandardizedDataType.bigint;
-	if (normalized === "smallint" || normalized.startsWith("smallint(")) return StandardizedDataType.smallint;
-	if (normalized === "tinyint" || normalized.startsWith("tinyint(")) return StandardizedDataType.tinyint;
-	if (normalized === "mediumint" || normalized.startsWith("mediumint(")) return StandardizedDataType.mediumint;
+	if (normalized === "bigint" || normalized.startsWith("bigint("))
+		return StandardizedDataType.bigint;
+	if (normalized === "smallint" || normalized.startsWith("smallint("))
+		return StandardizedDataType.smallint;
+	if (normalized === "tinyint" || normalized.startsWith("tinyint("))
+		return StandardizedDataType.tinyint;
+	if (normalized === "mediumint" || normalized.startsWith("mediumint("))
+		return StandardizedDataType.mediumint;
 	if (normalized.includes("int")) return StandardizedDataType.int;
 
 	if (normalized === "real" || normalized === "float" || normalized.startsWith("float("))
 		return StandardizedDataType.float;
-	if (normalized === "double" || normalized === "double precision" || normalized.startsWith("double("))
+	if (
+		normalized === "double" ||
+		normalized === "double precision" ||
+		normalized.startsWith("double(")
+	)
 		return StandardizedDataType.double;
 
 	if (


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Addresses all actionable CodeRabbit suggestions from PR #189 (SQLite support), excluding the SQL injection finding per request.

- **Stable pagination**: Append PK tie-breaker columns to `ORDER BY` in `getTableData` so cursor-based pagination doesn't skip/duplicate rows when the sort column has non-unique values
- **Error mapping (503)**: Wrap `getDatabasesList`, `getCurrentDatabase`, `getDatabaseConnectionInfo`, `getTablesList`, `getTableSchema`, and `getTableColumns` in `try/catch { throw this.wrapError(e) }` so `better-sqlite3` / filesystem errors map to 503 instead of surfacing as generic errors
- **Consistent JSON serialization**: Serialize object/array values in `addRecord` and `bulkInsertRecords` with `JSON.stringify`, matching the existing behavior in `updateRecords`
- **Preserve schema objects on `alterColumn`**: Read `CREATE INDEX` and `CREATE TRIGGER` statements from `sqlite_master` before the table rebuild and re-execute them after the rename, so indexes and triggers are not silently dropped
- **SQLite handle cleanup**: Call `closeSqliteDb()` inside `closePool()` and `closePoolByDatabase()` so selective-close paths don't leave the file handle open
- **Parameterized type labels**: Fix `standardizeSqliteDataTypeLabel` to match `bigint(20)`, `smallint(6)`, `tinyint(1)`, `mediumint(8)`, `float(8)`, `double(10)` before the generic `includes("int")` fallback

## Test plan

- [ ] All 923 existing server tests pass (`bun run test` in `packages/server`)
- [ ] Biome format passes with no errors
- [ ] Paginating a table sorted by a non-unique column does not skip/duplicate rows across pages
- [ ] Altering a column on a table that has extra indexes or triggers preserves them
- [ ] Inserting a record with a JSON/array column stores the value as serialized JSON (consistent with updates)
- [ ] Connection errors from SQLite file operations surface as HTTP 503

https://claude.ai/code/session_01WzT1NRL9DK1uEjkew7H24q
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzT1NRL9DK1uEjkew7H24q)_