### PR TITLE
chore: remove Product Hunt header banner and README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ A modern, universal (pgAdmin alternative) database management studio for any dat
 
 <br>
 
-<a href="https://www.producthunt.com/products/dbstudio-sh/launches/dbstudio-sh?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-dbstudio-sh" target="_blank" rel="noopener noreferrer"><img alt="dbstudio.sh - A modern pgAdmin alternative that works with every database | Product Hunt" width="180" height="40" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1056391&amp;theme=light&amp;t=1777406433935"></a>
-
-<br>
-
 <img src="assets/screenshot.png" alt="DB Studio screenshot" width="1000" />
 </div>
 

--- a/www/src/routes/(main)/_pathlessLayout.tsx
+++ b/www/src/routes/(main)/_pathlessLayout.tsx
@@ -1,6 +1,4 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
-import { RocketIcon, XIcon } from "lucide-react";
-import { useState } from "react";
 import { Footer } from "@/components/footer";
 import { Header } from "@/components/header";
 import { getStarsCount } from "@/utils/get-stars-count";
@@ -13,43 +11,10 @@ export const Route = createFileRoute("/(main)/_pathlessLayout")({
 	},
 });
 
-function ProductHuntBanner() {
-	const [dismissed, setDismissed] = useState(false);
-
-	if (dismissed) return null;
-
-	return (
-		<div className="w-full bg-[#4B70FF] text-white text-sm flex items-center justify-center gap-3 px-4 py-2.5 relative">
-			<RocketIcon className="size-4 shrink-0" />
-			<span>
-				We&apos;re live on Product Hunt! If you&apos;re enjoying db-studio, support us with an
-				upvote.
-			</span>
-			<a
-				href="https://www.producthunt.com/products/dbstudio-sh/launches/dbstudio-sh"
-				target="_blank"
-				rel="noopener noreferrer"
-				className="shrink-0 rounded border border-white/60 px-2.5 py-0.5 text-xs font-medium hover:bg-white/10 transition-colors"
-			>
-				Upvote us!
-			</a>
-			<button
-				type="button"
-				onClick={() => setDismissed(true)}
-				className="absolute right-3 top-1/2 -translate-y-1/2 p-1 hover:bg-white/10 rounded transition-colors"
-				aria-label="Dismiss banner"
-			>
-				<XIcon className="size-3.5" />
-			</button>
-		</div>
-	);
-}
-
 function RouteComponent() {
 	const { stars } = Route.useLoaderData();
 	return (
 		<main className="relative min-h-dvh w-full flex flex-col h-full z-10">
-			<ProductHuntBanner />
 			<div className="px-4 md:px-0 flex flex-col flex-1">
 				<Header stars={stars} />
 				<Outlet />


### PR DESCRIPTION
## Summary

- Removes the `ProductHuntBanner` component from the www site layout (`_pathlessLayout.tsx`)
- Removes the Product Hunt featured badge from `README.md`

## Test plan

- [ ] Verify the www site header no longer shows the Product Hunt banner
- [ ] Verify the README no longer displays the Product Hunt badge

https://claude.ai/code/session_01Abq8E13DCHdNcJSbGWBCL9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abq8E13DCHdNcJSbGWBCL9)_