### PR TITLE
docs(#readme): fix license badge — wrong repo name (pstrack → db-studio)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A modern, universal (pgAdmin alternative) database management studio for any dat
     <img src="https://img.shields.io/npm/dm/db-studio?style=flat-rounded" />
   </a>
   <a href="https://github.com/husamql3/db-studio/blob/main/LICENSE">
-    <img alt="License" src="https://img.shields.io/github/license/husamql3/pstrack">
+    <img alt="License" src="https://img.shields.io/github/license/husamql3/db-studio">
   </a>
   <a href="https://deepwiki.com/husamql3/db-studio">
     <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki">


### PR DESCRIPTION
## Summary
- **Fixed broken license badge** — the `License` shield was pointing to `husamql3/pstrack` instead of `husamql3/db-studio`, causing the badge to display pstrack's license rather than this repo's

## Change

```diff
-  <img alt="License" src="https://img.shields.io/github/license/husamql3/pstrack">
+  <img alt="License" src="https://img.shields.io/github/license/husamql3/db-studio">
```

## Testing
Open the README on GitHub after merge — the License badge should render correctly and link to the MIT license in this repo.

---

## Glossary
| Term | Definition |
|------|------------|
| shields.io | Badge CDN that renders live metadata (version, license, downloads) as SVG images |
| `github/license` | shields.io endpoint that fetches the license from a GitHub repo by `owner/repo` slug |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README license badge to point to the current repository’s license information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->