### PR TITLE
chore(#217): bump version to 1.9.4

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "db-studio",
   "type": "module",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Modern database client for PostgreSQL with spreadsheet-like grid, AI-powered SQL assistance, ER diagrams, fast data browsing and editing. CLI tool, upcoming desktop & web versions.",
   "keywords": [
     "database client",
@@ -24,7 +24,7 @@
     "database management",
     "database studio"
   ],
-  "author": "Hüsam 🥑 <devhsmq@gmail.com>",
+  "author": "H\u00fcsam \ud83e\udd51 <devhsmq@gmail.com>",
   "homepage": "https://dbstudio.sh",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- **Bump `packages/server/package.json` version 1.9.3 → 1.9.4** — patch release packaging all the dep and doc updates already merged to stage

Closes #217

---

## Glossary
| Term | Definition |
|------|------------|
| `packages/server` | The npm-published workspace package (`db-studio` on npm); its `version` field drives the npm publish step in the release workflow |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the server package version to **1.9.4**.
  * Refreshed package metadata formatting for the author field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->