### PR TITLE
chore(#217): add v1.9.4 changelog entry

### DIFF
--- a/www/src/lib/content/changelog.ts
+++ b/www/src/lib/content/changelog.ts
@@ -16,6 +16,24 @@ export type ChangelogItem = {
 
 export const changelog: ChangelogItem[] = [
 	{
+		version: "1.9.4",
+		date: "2026-07-02",
+		title: "Dependency updates and README fix",
+		improvements: [
+			{
+				text: "Updated production dependencies: @tanstack/ai (0.16→0.38), @tanstack/ai-react (0.8→0.16), @tanstack/react-router (1.170.2→1.170.16), @tanstack/react-start (1.168.3→1.168.26), commander (14→15), three (0.184→0.185)",
+			},
+			{
+				text: "Updated dev dependencies (6 packages)",
+			},
+		],
+		bugsFixed: [
+			{
+				text: "Fixed license badge in README pointing to wrong repository",
+			},
+		],
+	},
+	{
 		version: "1.9.3",
 		date: "2026-05-16",
 		title: "Fix the database connection error",


### PR DESCRIPTION
## Summary
- **Adds `1.9.4` entry to `changelog.ts`** — the release workflow's `generate-release-notes.js` exits 1 when the version isn't in the changelog, which caused the GitHub release creation step to be skipped. The GitHub release was created manually; this entry prevents the same failure on future releases.

Refs #217

---

## Glossary
| Term | Definition |
|------|------------|
| `changelog.ts` | Source-of-truth changelog consumed by the website and by `scripts/generate-release-notes.js` to produce GitHub release bodies |