### PR TITLE
docs(#217): fix npm URLs and license badge in packages/server/README.md

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -6,14 +6,14 @@ A modern, universal (pgAdmin alternative) database management studio for any dat
   <a href="https://github.com/husamql3/db-studio/stargazers">
     <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/husamql3/db-studio">
   </a>
-  <a href="https://www.npmjs.com/package/dbstudio">
-    <img src="https://img.shields.io/npm/v/dbstudio?style=flat-rounded" />
+  <a href="https://www.npmjs.com/package/db-studio">
+    <img src="https://img.shields.io/npm/v/db-studio?style=flat-rounded" />
   </a>
-  <a href="https://www.npmjs.com/package/dbstudio">
-    <img src="https://img.shields.io/npm/dm/dbstudio?style=flat-rounded" />
+  <a href="https://www.npmjs.com/package/db-studio">
+    <img src="https://img.shields.io/npm/dm/db-studio?style=flat-rounded" />
   </a>
   <a href="https://github.com/husamql3/db-studio/blob/main/LICENSE">
-    <img alt="License" src="https://img.shields.io/github/license/husamql3/pstrack">
+    <img alt="License" src="https://img.shields.io/github/license/husamql3/db-studio">
   </a>
   <a href="https://deepwiki.com/husamql3/db-studio">
     <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki">


### PR DESCRIPTION
## Summary
- **Fixed wrong npm package name** — `packages/server/README.md` (the README rendered on the npm page) had `dbstudio` (no hyphen) instead of `db-studio` in all npm badge hrefs and shield image URLs
- **Fixed license badge** — same file had `husamql3/pstrack` in the license shield URL, now `husamql3/db-studio`

This is the README that npm.js renders when someone views the `db-studio` package page.

Refs #217

---

## Glossary
| Term | Definition |
|------|------------|
| `packages/server/README.md` | The README bundled inside the published npm tarball — distinct from the root README shown on GitHub |