### PR TITLE
chore(#217): bump version to 1.9.5

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "db-studio",
   "type": "module",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Modern database client for PostgreSQL with spreadsheet-like grid, AI-powered SQL assistance, ER diagrams, fast data browsing and editing. CLI tool, upcoming desktop & web versions.",
   "keywords": [
     "database client",

--- a/www/src/lib/content/changelog.ts
+++ b/www/src/lib/content/changelog.ts
@@ -16,6 +16,16 @@ export type ChangelogItem = {
 
 export const changelog: ChangelogItem[] = [
 	{
+		version: "1.9.5",
+		date: "2026-07-02",
+		title: "Fix npm package URLs in README",
+		bugsFixed: [
+			{
+				text: "Fixed npm package URLs in the published README pointing to wrong package name (dbstudio → db-studio) and wrong license badge repo",
+			},
+		],
+	},
+	{
 		version: "1.9.4",
 		date: "2026-07-02",
 		title: "Dependency updates and README fix",


### PR DESCRIPTION
## Summary
- **Bump version 1.9.4 → 1.9.5** — npm rejects re-publishing the same version; the README fix to `packages/server/README.md` (wrong npm URLs) requires a new version to land on the npm package page
- **Add `1.9.5` changelog entry** — prevents release notes script from failing on next main push

Refs #217

---

## Glossary
| Term | Definition |
|------|------------|
| npm version immutability | Once a version is published to npm it cannot be overwritten — a new version number is required for any change to the published package content |