### PR TITLE
fix(#214): namespace HTTP API under /api to stop SPA route collision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,125 @@
+# db-studio — Domain Context
+
+This is the canonical glossary for db-studio. Terms here are the names domain experts
+use; treat any drift in code or conversation as a signal to either correct the code or
+update this file.
+
+## Deployment shapes
+
+db-studio runs in one of two shapes:
+
+- **Standalone (OSS)**: a single user runs `npx db-studio` against their own database.
+  One process, one `DATABASE_URL` from env, one tenant. This is the historical shape
+  and remains the OSS product.
+- **Hosted (multi-tenant) — private fork**: a separate, private fork of db-studio is
+  embedded inside a larger hosting platform that owns many databases on behalf of many
+  of its own users. The hosting platform routes incoming traffic to the fork and
+  supplies, per request, the database URL to operate against. **The fork is not a CLI**
+  — it's a long-running application/service. CLI compatibility is therefore not a
+  constraint on the fork's design.
+
+## Terms
+
+### `dbType`
+The database **engine** — one of `pg`, `mysql`, `mssql`, `mongodb`, `sqlite`, `redis`.
+Always derivable from the protocol of a database URL (`postgres://` → `pg`, etc.).
+Already appears as the first path segment in every API URL (`/:dbType/...`).
+
+### `dbName` *(hosted shape only)*
+A **hosting-platform-level identifier** for one of the databases the platform hosts.
+It is *not* a term db-studio itself knows about — it lives in the hosting platform's
+URL space (e.g. `platform.com/:dbName/...`). The platform is responsible for resolving
+`:dbName` to a concrete database URL and passing that URL through to db-studio on every
+request. From db-studio's point of view, requests always come in shaped as `/:dbType/...`.
+
+### `database` (CLI flag, route query param, function arg)
+The **logical database** (catalog / schema / Mongo db / Redis logical index) inside a
+connected server. Different from `dbName` — `database` lives inside a single connection,
+`dbName` selects which connection to use in the first place.
+
+## Hosted-fork architecture (decided so far)
+
+- **Channel topology**: the fork is served at `studio.platform.com`. The platform
+  itself lives at `platform.com` (or `app.platform.com`). Same registrable domain →
+  cookies can be scoped to `Domain=.platform.com`.
+- **Per-request connection config**: a JWE (encrypted + signed JWT) carries the DB
+  URL from the platform to the fork. The platform and fork share a symmetric key.
+  Tokens are short-lived; renewal is the platform's responsibility.
+- **Transport**: JWE is delivered as an `HttpOnly; Secure; SameSite=Lax` cookie on
+  `.platform.com`, set by the platform server-side before the user reaches the fork.
+  The browser auto-forwards it on every fork API call. SPA JS never touches it.
+- **Singleton removal**: the fork's `DatabaseManager` keeps the pool-cache (keyed by
+  connection string) but loses `baseConfig` and the env-driven init. A request-scoped
+  middleware decrypts the JWE → derives the connection config → derives `dbType` from
+  the URL protocol → sets both on the Hono context. Adapters pull from the context.
+- **URL structure inside the fork**: unchanged from OSS — still `/:dbType/...`. The
+  `:dbName` from the platform's URL space never enters the fork.
+- **JWE scope**: one JWE = one specific database, with credentials for a role that
+  the platform provisioned against that single DB (e.g. `pstrack-user` against
+  `pstrack`). The fork never sees a server-wide admin connection. A leaked token
+  grants exactly what the underlying DB role grants — no more.
+- **Permission enforcement**: the DB role itself is the source of truth. The fork
+  does *not* implement its own ACL layer on top. The raw-SQL editor stays available
+  in hosted mode for the same reason — withholding it would not improve security,
+  since the same role's credentials can be used outside the fork.
+- **Bootstrap flow**: clicking "Open" in the platform hits a platform backend route
+  that (1) generates a JWE for the target DB, (2) sets it as an `HttpOnly; Secure;
+  SameSite=Lax` cookie on `Domain=.platform.com`, (3) 302s the browser to a deep
+  link `studio.platform.com/:dbType/tables` (or similar). The dbType is in the URL,
+  not derived from a `/session` call. The JWE middleware asserts the URL's `:dbType`
+  matches the JWE's protocol — a mismatch fails fast as a 400.
+- **JWE expiry / renewal**: TTL = 1 hour. On a 401, the fork's SPA performs a
+  **silent refresh** against a platform-side endpoint (`platform.com/api/db-studio/refresh`)
+  with credentials. If the platform returns a refreshed cookie, the SPA retries the
+  original request transparently — user notices nothing. If the platform itself
+  returns 401 (platform session also gone), the SPA redirects the browser to the
+  platform's login page with a `next=` back to the same database. The refresh URL
+  is provided to the SPA via a build-time env or injected into the bootstrap HTML.
+- **Connection pooling**: the platform does **not** expose a connection pooler in
+  front of customer DBs — the fork connects directly. Therefore the fork keeps its
+  own per-tenant pool cache, with:
+  - `max: 2` connections per pool (vs. OSS's 10) — one in-flight + one spare is
+    enough for a single user browsing one tab; the actual customer's app needs the
+    rest of the DB's connection budget.
+  - Idle eviction after 5 min: a background sweeper closes pools whose
+    `lastAccessedAt` is older than the threshold.
+  - Hard cap of 500 pools per fork process, with LRU eviction on insert when full.
+  - Mongo and Redis client maps must be **re-keyed by connection string** (today
+    they're keyed by single-server / db-index — fine for OSS, wrong for the fork).
+- **Cross-DB enforcement**: handled by the underlying DB role, **not** by fork code.
+  The `pstrack-user` role can only connect to / see the `pstrack` database; any
+  attempt to operate on another DB fails at the DB layer (permission denied →
+  surfaced as 503 by `BaseAdapter.wrapError`). The fork does **not** validate
+  user-supplied `?db=...` against the JWE's DB name, and does **not** strip the
+  query param. Route handlers continue to call `getDbPool(c.req.valid("query").db)`
+  unchanged. The trade-off: a stale or malicious SPA sending `?db=other_db` gets a
+  somewhat confusing DB-level error instead of a clean 403, and the existence of
+  other DBs may leak via timing/wording. Accepted, because:
+  1. The DB role is the real security boundary either way.
+  2. Adding fork-level checks would be validation theater (validating user input
+     against a server-known truth — the answer should never come from the user).
+  3. It keeps route code identical to OSS, making upstream merges cheap.
+- **Frontend hosted-mode UI**: the fork's FE detects hosted mode (via a build-time
+  flag, e.g. `VITE_DB_STUDIO_MODE=hosted`) and **collapses the databases tier of the
+  sidebar entirely**. The platform's own UI is the database-selection UI; the fork
+  renders one DB and shows the tables list as the top-level sidebar tier. The
+  "create database" / "delete database" / database-switcher affordances are hidden
+  in hosted mode.
+- **JWE payload**:
+  ```json
+  {
+    "iss": "platform.com",
+    "aud": "studio.platform.com",
+    "iat": 1747551600,
+    "exp": 1747555200,
+    "jti": "01J5T9...",
+    "db_url": "postgres://pstrack-user:<pw>@host:5432/pstrack",
+    "platform_user_id": "user_abc123",
+    "platform_db_id": "db_xyz789"
+  }
+  ```
+  Plus `kid` in the JWE protected header for key rotation (included from day one,
+  not retrofitted). `dbType` is **not** in the payload — derivable from `db_url`'s
+  protocol; single source of truth. No `scopes` field — ACL is the DB role's job.
+  `platform_user_id` and `platform_db_id` are present specifically so the fork can
+  emit audit-able logs that correlate to the platform's records.

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
       "devDependencies": {
         "husky": "^9.1.7",
         "knip": "^6.14.1",
-        "portless": "^0.13.0",
+        "portless": "^0.14.0",
       },
       "peerDependencies": {
         "typescript": "^6.0.3",
@@ -21,8 +21,8 @@
       "name": "@db-studio/proxy",
       "dependencies": {
         "@db-studio/shared": "workspace:*",
-        "@tanstack/ai": "^0.16.0",
-        "@tanstack/ai-gemini": "^0.10.0",
+        "@tanstack/ai": "^0.38.0",
+        "@tanstack/ai-gemini": "^0.18.3",
         "@upstash/redis": "^1.36.1",
         "hono": "^4.11.3",
         "hono-rate-limiter": "^0.5.3",
@@ -34,7 +34,7 @@
     },
     "packages/server": {
       "name": "db-studio",
-      "version": "1.9.3",
+      "version": "1.9.5",
       "bin": {
         "db-studio": "./dist/index.js",
       },
@@ -43,7 +43,7 @@
         "@hono/node-server": "^2.0.0",
         "@hono/zod-validator": "^0.8.0",
         "better-sqlite3": "^12.9.0",
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "dotenv": "^17.3.1",
         "hono": "^4.10.4",
         "ioredis": "^5.4.1",
@@ -60,7 +60,7 @@
         "@db-studio/shared": "workspace:*",
         "@types/better-sqlite3": "^7.6.13",
         "@types/mssql": "^12.3.0",
-        "@types/node": "^25.6.0",
+        "@types/node": "^26.0.0",
         "@types/pg": "^8.16.0",
         "@vitest/coverage-v8": "^4.0.17",
         "tsup": "^8.5.1",
@@ -127,7 +127,7 @@
         "tailwindcss": "^4.1.18",
         "tw-animate-css": "^1.4.0",
         "typescript": "^6.0.3",
-        "vite": "^8.0.12",
+        "vite": "^8.0.16",
       },
       "peerDependencies": {
         "react": "^19.2.0",
@@ -163,10 +163,10 @@
         "@radix-ui/react-use-controllable-state": "^1.2.2",
         "@sentry/react": "^10.52.0",
         "@tailwindcss/vite": "^4.1.18",
-        "@tanstack/ai": "^0.16.0",
-        "@tanstack/ai-react": "^0.8.0",
+        "@tanstack/ai": "^0.38.0",
+        "@tanstack/ai-react": "^0.16.0",
         "@tanstack/react-query": "^5.90.12",
-        "@tanstack/react-router": "^1.170.2",
+        "@tanstack/react-router": "^1.170.16",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.13",
         "@uiw/react-json-view": "^2.0.0-alpha.40",
@@ -202,20 +202,20 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.6",
-        "@tanstack/ai-devtools-core": "^0.3.19",
-        "@tanstack/devtools-vite": "^0.6.0",
+        "@tanstack/ai-devtools-core": "^0.4.12",
+        "@tanstack/devtools-vite": "^0.8.0",
         "@tanstack/react-ai-devtools": "^0.2.0",
         "@tanstack/react-devtools": "^0.10.3",
         "@tanstack/react-query-devtools": "^5.91.1",
         "@tanstack/react-router-devtools": "^1.167.0",
         "@tanstack/router-plugin": "^1.145.10",
-        "@types/node": "^25.6.0",
+        "@types/node": "^26.0.0",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.1",
+        "@vitejs/plugin-react": "^6.0.2",
         "rollup-plugin-visualizer": "^7.0.1",
         "typescript": "^6.0.3",
-        "vite": "^8.0.12",
+        "vite": "^8.0.16",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -231,10 +231,10 @@
         "@react-three/fiber": "^9.4.2",
         "@tailwindcss/vite": "^4.0.6",
         "@tanstack/react-devtools": "^0.10.2",
-        "@tanstack/react-router": "1.170.2",
+        "@tanstack/react-router": "1.170.16",
         "@tanstack/react-router-devtools": "1.167.0",
-        "@tanstack/react-start": "1.168.3",
-        "@types/three": "^0.184.0",
+        "@tanstack/react-start": "1.168.26",
+        "@types/three": "^0.185.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "fumadocs-core": "^16.4.1",
@@ -250,21 +250,21 @@
         "rough-notation": "^0.5.1",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.0.6",
-        "three": "^0.184.0",
+        "three": "^0.185.0",
         "tw-animate-css": "^1.4.0",
         "vite-tsconfig-paths": "^6.1.1",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.5",
         "@cloudflare/vite-plugin": "^1.19.0",
-        "@tanstack/devtools-vite": "^0.6.0",
-        "@types/node": "^25.6.0",
+        "@tanstack/devtools-vite": "^0.8.0",
+        "@types/node": "^26.0.0",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
-        "@vitejs/plugin-react": "6.0.1",
+        "@vitejs/plugin-react": "6.0.2",
         "jsdom": "^29.0.2",
         "typescript": "^6.0.3",
-        "vite": "8.0.12",
+        "vite": "8.0.16",
         "vitest": "^4.1.4",
         "wrangler": "^4.56.0",
       },
@@ -276,7 +276,7 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
-    "@ag-ui/core": ["@ag-ui/core@0.0.49", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-9ywypwjUGtIvTxJ2eKQjhPZgLnSFAfNK7vZUcT7Bz4ur4yAIB+lAFtzvu7VDYe6jsUx/6N/71Dh4R0zX5woNVw=="],
+    "@ag-ui/core": ["@ag-ui/core@0.0.52", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
@@ -538,7 +538,7 @@
 
     "@fumadocs/tailwind": ["@fumadocs/tailwind@0.0.5", "", { "peerDependencies": { "@tailwindcss/oxide": "^4.0.0", "tailwindcss": "^4.0.0" }, "optionalPeers": ["@tailwindcss/oxide", "tailwindcss"] }, "sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ=="],
 
-    "@google/genai": ["@google/genai@1.51.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-vTZZF3CSimN7cn2zsLpW2p5WF0eZa5Gz69ITMPCNHpPrDlAstOfGifSfi0p/s9Z9400f7xJRkgvkQNrcM7pJ6w=="],
+    "@google/genai": ["@google/genai@2.10.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg=="],
 
     "@hono/client": ["@hono/client@0.0.3", "", {}, "sha512-1TrYdppLelv39uCqevePjKUeyf4AoKYWQ+/qfNtRzY8OPBur78XA1Gtv3Pi08uXT6GOuQN5fi3IFUwMsxnEhcQ=="],
 
@@ -898,37 +898,37 @@
 
     "@react-three/fiber": ["@react-three/fiber@9.6.1", "", { "dependencies": { "@babel/runtime": "^7.17.8", "@types/webxr": "*", "base64-js": "^1.5.1", "buffer": "^6.0.3", "its-fine": "^2.0.0", "react-use-measure": "^2.1.7", "scheduler": "^0.27.0", "suspend-react": "^0.1.3", "use-sync-external-store": "^1.4.0", "zustand": "^5.0.3" }, "peerDependencies": { "expo": ">=43.0", "expo-asset": ">=8.4", "expo-file-system": ">=11.0", "expo-gl": ">=11.0", "react": ">=19 <19.3", "react-dom": ">=19 <19.3", "react-native": ">=0.78", "three": ">=0.156" }, "optionalPeers": ["expo", "expo-asset", "expo-file-system", "expo-gl", "react-dom", "react-native"] }, "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.4", "", { "os": "android", "cpu": "arm64" }, "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.1", "", { "os": "linux", "cpu": "arm" }, "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.4", "", { "os": "linux", "cpu": "arm" }, "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.1", "", { "os": "none", "cpu": "arm64" }, "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.4", "", { "os": "none", "cpu": "arm64" }, "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.1", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.4", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
@@ -1032,7 +1032,7 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
@@ -1080,31 +1080,33 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.4", "", { "dependencies": { "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "tailwindcss": "4.2.4" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw=="],
 
-    "@tanstack/ai": ["@tanstack/ai@0.16.0", "", { "dependencies": { "@ag-ui/core": "0.0.49", "@tanstack/ai-event-client": "0.3.0", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-EsMGoMp9Y/H3A4JkhZZhfqk6S8bUxVcoJZhJea2omJtyv58YjcLlqBQFKYx+64egkYOgoORDyxj6bNI6Ne7dcA=="],
+    "@tanstack/ai": ["@tanstack/ai@0.38.0", "", { "dependencies": { "@ag-ui/core": "^0.0.52", "@standard-schema/spec": "^1.1.0", "@tanstack/ai-event-client": "0.6.8", "@tanstack/ai-utils": "0.3.1", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-fAX8pmaLXRx8jB8v4CyYqCxCAagvHzvmU7l4J89XkKlzuun69F/pumcKFUOGxZyQswiz1+pzfmNwscv7K8AJmA=="],
 
-    "@tanstack/ai-client": ["@tanstack/ai-client@0.8.0", "", { "dependencies": { "@tanstack/ai": "0.14.0", "@tanstack/ai-event-client": "0.2.8" } }, "sha512-8G3mKwVWn/lwZlUcZgm1aTYWB96otFmr6LsYT+dOehOq1SrR8SiSbkSOVzozQXkfZFviHSueZXlLe/J6LrbVOg=="],
+    "@tanstack/ai-client": ["@tanstack/ai-client@0.19.2", "", { "dependencies": { "@tanstack/ai": "0.39.1", "@tanstack/ai-event-client": "0.6.8", "@tanstack/ai-utils": "0.3.1" } }, "sha512-j0wDA25RkNdshWdKbdqAI9e5FhpLS0FdP5Jr/N6iudiBvf3LiGs421tzsc5FSQqMJehzzUOdIi0JVzIVPCbGcw=="],
 
-    "@tanstack/ai-devtools-core": ["@tanstack/ai-devtools-core@0.3.25", "", { "dependencies": { "@tanstack/ai": "0.14.0", "@tanstack/ai-event-client": "0.2.8", "@tanstack/devtools-ui": "^0.5.1", "@tanstack/devtools-utils": "^0.4.0", "goober": "^2.1.18", "solid-js": "^1.9.10" } }, "sha512-nu7OtdCF1a86aRXVQEMU5Z30WcFuAbgjWvD7WtFJl73T0CiM+8bCywYE9giaw8kR42+EZ8eUzE2tUV2TI0JrtQ=="],
+    "@tanstack/ai-devtools-core": ["@tanstack/ai-devtools-core@0.4.21", "", { "dependencies": { "@tanstack/ai": "0.39.1", "@tanstack/ai-event-client": "0.6.8", "@tanstack/devtools-ui": "^0.5.1", "@tanstack/devtools-utils": "^0.4.0", "goober": "^2.1.18", "solid-js": "^1.9.10" } }, "sha512-rFheKLoi6ePwyNVoncoljnHqqhtFLpFhUbNFGxd6sZa5gTtcYbekRP3rrNNM68KwA+c32Kz5jLnsJbDNV6A6zg=="],
 
-    "@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.3.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.16.0" } }, "sha512-rAXrgLgyxDszd1PVBWH4wpOyP89QpKLY6oAg8eBx44hVhEpkCM50AaoiDtrPCmxMjrucBz9OMkAU2Khb7EaZ6g=="],
+    "@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.6.8", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" } }, "sha512-h7/HLz9u2LF9ba6uKFMnSZkFlkzQONJ5u3Hi+4qGxpsHyvcGRtW6v186jaFLoklndhEwyC49ytkC4eafi7Qq8w=="],
 
-    "@tanstack/ai-gemini": ["@tanstack/ai-gemini@0.10.0", "", { "dependencies": { "@google/genai": "^1.43.0" }, "peerDependencies": { "@tanstack/ai": "^0.14.0" } }, "sha512-AlkvO6afSu2k142te1Yc6MS3jNi/5J3tf0TLxzTInfeCg87pNLiZ95IVru6/XA1gfWJfcYmRnP9vGcRbQYyF5Q=="],
+    "@tanstack/ai-gemini": ["@tanstack/ai-gemini@0.18.4", "", { "dependencies": { "@google/genai": "^2.8.0", "@tanstack/ai-utils": "0.3.1", "partial-json": "^0.1.7" }, "peerDependencies": { "@tanstack/ai": "^0.39.0" } }, "sha512-Mfm1cB53KA5NS8cXusRrZIvGuQWsK86PsIp4PAeiTPBxJ4U5oKX8T3N40XbgXENKu/LjOe8gHSHbp63+acrknw=="],
 
-    "@tanstack/ai-react": ["@tanstack/ai-react@0.8.0", "", { "dependencies": { "@tanstack/ai-client": "0.8.0" }, "peerDependencies": { "@tanstack/ai": "^0.14.0", "@types/react": ">=18.0.0", "react": ">=18.0.0" } }, "sha512-SP0erLxGhjFnGuunjUmFkIfCR3Uqj98RuMG3k2Qxlzy3F03K/JZWwufJvz7QJohaE8OLKc6m6TuxXAZ7Zk7//A=="],
+    "@tanstack/ai-react": ["@tanstack/ai-react@0.16.3", "", { "dependencies": { "@tanstack/ai-client": "0.19.2" }, "peerDependencies": { "@mcp-ui/client": "^7", "@tanstack/ai": "^0.39.1", "@types/react": ">=18.0.0", "react": ">=18.0.0" }, "optionalPeers": ["@mcp-ui/client"] }, "sha512-UaIkUU13YGdgCBCwb5tbO1Xz/5bEeVTd6kVmBizGP9tlSrMXTtLcU0tlup/fy+MYIi+F3wAtyS4c53VkkupvuA=="],
+
+    "@tanstack/ai-utils": ["@tanstack/ai-utils@0.3.1", "", {}, "sha512-fgbjd5DohL3k5rTWr/KInauLVYMiHVm0cnmTsNrzL3cr4wWhEld5vmFSrjiwUWACAuONjZa+uBXuS+ZSO8fwDQ=="],
 
     "@tanstack/devtools": ["@tanstack/devtools@0.12.2", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.3", "@solid-primitives/keyboard": "^1.3.3", "@solid-primitives/resize-observer": "^2.1.3", "@tanstack/devtools-client": "0.0.6", "@tanstack/devtools-event-bus": "0.4.1", "@tanstack/devtools-ui": "0.5.2", "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.9" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-Xdl8pLzoDUvXaclQ0poY36WAPx0jEHk8vqUFd8FYFUm1BMshtB7RnTgD1HE9jCAXODxqw9I0gXBiUZLK3o3+Bw=="],
 
-    "@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.6", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" } }, "sha512-f85ZJXJnDIFOoykG/BFIixuAevJovCvJF391LPs6YjBAPhGYC50NWlx1y4iF/UmK5/cCMx+/JqI5SBOz7FanQQ=="],
+    "@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.8", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.5.0" } }, "sha512-cG3iZkGWCwN330bLBKa8+9r4Of2AXNoz2zUqcsy/4XsD3105ghVBx78cGyvJj9fSclNomPxoqAnDGXXhg1WLvA=="],
 
-    "@tanstack/devtools-event-bus": ["@tanstack/devtools-event-bus@0.4.1", "", { "dependencies": { "ws": "^8.18.3" } }, "sha512-cNnJ89Q021Zf883rlbBTfsaxTfi2r73/qejGtyTa7ksErF3hyDyAq1aTbo5crK9dAL7zSHh9viKY1BtMls1QOA=="],
+    "@tanstack/devtools-event-bus": ["@tanstack/devtools-event-bus@0.4.2", "", { "dependencies": { "ws": "^8.18.3" } }, "sha512-2LHzhwBFlKHCcklsQrGe8TeyjHd4XAF8nuCO6wHmva5fePUkJUULbu6CsCNAlGlCi0KkEsMXZSvRdR4HgMq4yA=="],
 
     "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.3", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw=="],
 
-    "@tanstack/devtools-ui": ["@tanstack/devtools-ui@0.5.1", "", { "dependencies": { "clsx": "^2.1.1", "dayjs": "^1.11.19", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-T9JjAdqMSnxsVO6AQykD5vhxPF4iFLKtbYxee/bU3OLlk446F5C1220GdCmhDSz7y4lx+m8AvIS0bq6zzvdDUA=="],
+    "@tanstack/devtools-ui": ["@tanstack/devtools-ui@0.5.2", "", { "dependencies": { "clsx": "^2.1.1", "dayjs": "^1.11.19", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-GtaMk8kaGZ9ZdR8Pu5RAfcse/ZrxzH/xsAIFtHMapLs2VMqSPFfb1NvIDO1MAAfUcub8Ix8XKQEP0uYSPzoFKw=="],
 
     "@tanstack/devtools-utils": ["@tanstack/devtools-utils@0.4.0", "", { "peerDependencies": { "@types/react": ">=17.0.0", "preact": ">=10.0.0", "react": ">=17.0.0", "solid-js": ">=1.9.7", "vue": ">=3.2.0" }, "optionalPeers": ["@types/react", "preact", "react", "solid-js", "vue"], "bin": { "intent": "bin/intent.js" } }, "sha512-KsGzYhA8L/fCNgyyMyoUy+TKtx+DjNbzWwqH6wXL48Llzo7kvV9RynYJlaO8Qkzwm+NdHXSgsljQNjQ3CKPpZA=="],
 
-    "@tanstack/devtools-vite": ["@tanstack/devtools-vite@0.6.0", "", { "dependencies": { "@babel/core": "^7.28.4", "@babel/generator": "^7.28.3", "@babel/parser": "^7.28.4", "@babel/traverse": "^7.28.4", "@babel/types": "^7.28.4", "@tanstack/devtools-client": "0.0.6", "@tanstack/devtools-event-bus": "0.4.1", "chalk": "^5.6.2", "launch-editor": "^2.11.1", "picomatch": "^4.0.3" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-h0r0ct7zlrgjkhmn4QW6wRjgUXd4JMs+r7gtx+BXo9f5H9Y+jtUdtvC0rnZcPto6gw/9yMUq7yOmMK5qDWRExg=="],
+    "@tanstack/devtools-vite": ["@tanstack/devtools-vite@0.8.1", "", { "dependencies": { "@tanstack/devtools-client": "0.0.8", "@tanstack/devtools-event-bus": "0.4.2", "chalk": "^5.6.2", "launch-editor": "^2.11.1", "magic-string": "^0.30.0", "oxc-parser": "^0.120.0", "picomatch": "^4.0.3" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-oQxOo0fI0bwhHtw/psFlIR0OS/bsKrirBxwnw2vuhCM4bjt3k4EZZsW/lvZ1+Vpouhts7LSyvngnxvGXbQ1sUQ=="],
 
     "@tanstack/history": ["@tanstack/history@1.162.0", "", {}, "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA=="],
 
@@ -1120,17 +1122,17 @@
 
     "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.100.9", "", { "dependencies": { "@tanstack/query-devtools": "5.100.9" }, "peerDependencies": { "@tanstack/react-query": "^5.100.9", "react": "^18 || ^19" } }, "sha512-mM3slaVGXJmz+pOLgXdANj75ikgQCyudyl3kmFvm6brI1JyVeY/+IeD17uDHIvZrD8hfoO2sdZ54RFsHdYAuhA=="],
 
-    "@tanstack/react-router": ["@tanstack/react-router@1.170.2", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.0", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-OxbFxgwLUqF5jCLuMUWXpSXM3aEL5i6pzT/vE6AIFsUrwsWFzALviLQOgLKgmqN6Rd5HVoMYmqRdetRwzt8NVQ=="],
+    "@tanstack/react-router": ["@tanstack/react-router@1.170.17", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.14", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-ppLkjCfSMaeug9rmFRYzOd4TIqWV+yTE7tzIny7alJsSnM7w4lzEZm6eqCehG0SPetpZ0R3K+UnanSmBgOAVcQ=="],
 
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.167.0", "", { "dependencies": { "@tanstack/router-devtools-core": "1.168.0" }, "peerDependencies": { "@tanstack/react-router": "^1.170.0", "@tanstack/router-core": "^1.170.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-nGw095EG7IHx0h5NtlEmzf6vcCTaFNPWdTSuDKazajhN0ct/v/TkekJ9J6KYUCeV1a8/2ZmToc58M+0rrOyn7w=="],
 
-    "@tanstack/react-start": ["@tanstack/react-start@1.168.3", "", { "dependencies": { "@tanstack/react-router": "1.170.2", "@tanstack/react-start-client": "1.167.2", "@tanstack/react-start-rsc": "0.1.3", "@tanstack/react-start-server": "1.167.2", "@tanstack/router-utils": "1.162.0", "@tanstack/start-client-core": "1.169.2", "@tanstack/start-plugin-core": "1.170.3", "@tanstack/start-server-core": "1.168.2", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "@vitejs/plugin-rsc": "*", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "@vitejs/plugin-rsc", "vite"] }, "sha512-f19GyPma9MQ71E74B6xC+XQ8zjqGfti8eOo8wnBuXDLlyWapUZajev0Y69daJHKxBn2sfvji+2+oDGRhSzBYjg=="],
+    "@tanstack/react-start": ["@tanstack/react-start@1.168.26", "", { "dependencies": { "@tanstack/react-router": "1.170.16", "@tanstack/react-start-client": "1.168.14", "@tanstack/react-start-rsc": "0.1.25", "@tanstack/react-start-server": "1.167.20", "@tanstack/router-utils": "1.162.2", "@tanstack/start-client-core": "1.170.12", "@tanstack/start-plugin-core": "1.171.18", "@tanstack/start-server-core": "1.169.15", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "@vitejs/plugin-rsc": "*", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "@vitejs/plugin-rsc", "vite"] }, "sha512-ZzNecqKWC0p2643/kIcFUdsMrXZ8A4dXm4Yfe9zV/Y0u14MtSkh/Sk76RQYIU5S84VyDyKhHo0Ffh8HQbLdvFw=="],
 
-    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.167.2", "", { "dependencies": { "@tanstack/react-router": "1.170.2", "@tanstack/router-core": "1.171.0", "@tanstack/start-client-core": "1.169.2" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-ErE6culiN1TPp4a0eEaS7r1Z/tNCi3agI+gK/Ud/3azof4Sa12Vbp1FWqKpj56LDbhqA7M2EgFHFrs7Jxvl0xw=="],
+    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.168.14", "", { "dependencies": { "@tanstack/react-router": "1.170.16", "@tanstack/router-core": "1.171.13", "@tanstack/start-client-core": "1.170.12" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-oaz43fdOhBWfOPsdLkp3IejwYEXRyeaZ4CYexOPZx3eVXzm4LLozvNkkkBE9aje1sM5MVC2Yo6+cyv2HdVzkHQ=="],
 
-    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.1.3", "", { "dependencies": { "@tanstack/react-router": "1.170.2", "@tanstack/react-start-server": "1.167.2", "@tanstack/router-core": "1.171.0", "@tanstack/router-utils": "1.162.0", "@tanstack/start-client-core": "1.169.2", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-plugin-core": "1.170.3", "@tanstack/start-server-core": "1.168.2", "@tanstack/start-storage-context": "1.167.2", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.20", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-juRzmtRiNfcDINjSH/y0etPIGpJ4m/zcELv3ykq+boVud3xrrSjqSFnD/mi70LM1VJ1uG6MMRKXIxv8XskeP0w=="],
+    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.1.25", "", { "dependencies": { "@tanstack/react-router": "1.170.16", "@tanstack/router-core": "1.171.13", "@tanstack/router-utils": "1.162.2", "@tanstack/start-client-core": "1.170.12", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-plugin-core": "1.171.18", "@tanstack/start-server-core": "1.169.15", "@tanstack/start-storage-context": "1.167.15", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.20", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-Rwm6cjcS148y2XAebr8jyrwU0SqsRSkW4/CuXesoHg+G3IOnVRHV0HOylJfnznUTVuH1nVhfQRPI5uWPJaw2TA=="],
 
-    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.167.2", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-router": "1.170.2", "@tanstack/router-core": "1.171.0", "@tanstack/start-client-core": "1.169.2", "@tanstack/start-server-core": "1.168.2" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-+mOZU1zq1wlq3h5f4qRxUdg/kCxTi+qHZwy68V8zvCLGFfnaCTsozZpnT9MhFgg3q9PSgSVCt1EIwM128V5wEA=="],
+    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.167.20", "", { "dependencies": { "@tanstack/react-router": "1.170.16", "@tanstack/router-core": "1.171.13", "@tanstack/start-server-core": "1.169.15" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-hg9xVI6yNDu+6NCalKz1h3Ea18HZEUu35i/ZMJz1WadwqcArLMp41nM1GNhOAtGIdpycrp9tT7ccqc9zuRMRpQ=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
@@ -1148,15 +1150,15 @@
 
     "@tanstack/router-utils": ["@tanstack/router-utils@1.162.0", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-c3GhqhBRCP636B41nf3TKvVz8EWzC5PTZ3I4J4LDH2tVjpxbyFNYsQKRtbNWiMFl+GTtgK4nCha346Wv7j4hcQ=="],
 
-    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.169.2", "", { "dependencies": { "@tanstack/router-core": "1.171.0", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-storage-context": "1.167.2", "seroval": "^1.5.4" } }, "sha512-pQnxM992x6OJiQJu0LMrGlJqExR6kZ5evl5wdIvk1oCr60wgQXKSAiFJgdMaWcqOhjzgoprlRUKLlj0Bgy8Ngg=="],
+    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.170.12", "", { "dependencies": { "@tanstack/router-core": "1.171.13", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-storage-context": "1.167.15", "seroval": "^1.5.4" } }, "sha512-gwtZRMPUIAxmDV2AIQUhC0kSW262SV7BkHXEgy5B1woHQdrdsELuGOdJwdweLxrjyefORxk+9MYGqDY0Cxn0bw=="],
 
     "@tanstack/start-fn-stubs": ["@tanstack/start-fn-stubs@1.162.0", "", {}, "sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ=="],
 
-    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.170.3", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.0-beta.40", "@tanstack/router-core": "1.171.0", "@tanstack/router-generator": "1.167.3", "@tanstack/router-plugin": "1.168.3", "@tanstack/router-utils": "1.162.0", "@tanstack/start-client-core": "1.169.2", "@tanstack/start-server-core": "1.168.2", "cheerio": "^1.0.0", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.4", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-z1Np/PPaOEtaDIuKtimtRyPl4a0o2atYXZQs/kH3zOi3ni6Vyw1L8nXRlV2NA9Ooppy+fXOMhe89jmlFcpvVDA=="],
+    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.171.18", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.13", "@tanstack/router-generator": "1.167.17", "@tanstack/router-plugin": "1.168.18", "@tanstack/router-utils": "1.162.2", "@tanstack/start-server-core": "1.169.15", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.4", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-weuOOjRD03BiKcF9NYKL5QADEQOp3yGHb0qIsOX42ENz5XUE4in2fXcVYHjSwwpzs+XGhWIFLp5J385pOVPuZQ=="],
 
-    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.168.2", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/router-core": "1.171.0", "@tanstack/start-client-core": "1.169.2", "@tanstack/start-storage-context": "1.167.2", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.4" } }, "sha512-6NkqltymTf4UzW4VHTakHbIrZzG9w4SVolPZRPdOmtmT+8w8+jm1DTCVOTya0apOaJUfZpGopr89irMjpI2qUQ=="],
+    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.169.15", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/router-core": "1.171.13", "@tanstack/start-client-core": "1.170.12", "@tanstack/start-storage-context": "1.167.15", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.4" } }, "sha512-V8ie2G2Ecb3Nklk8/QuKzulxb+tDUqgz6rjJe8Isdp4iKVXZu/TscItkUP/4Q5Bu7W4gUy3P25O6soC1oW1SXQ=="],
 
-    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.167.2", "", { "dependencies": { "@tanstack/router-core": "1.171.0" } }, "sha512-QUlEGNnKZ1aD43bZiyT4ZSO9BZofAF60DMISuXFE4crajjoUDTwnIrH01kkCNcL9AiiHSFCmphPx3jAbA3oNRA=="],
+    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.167.15", "", { "dependencies": { "@tanstack/router-core": "1.171.13" } }, "sha512-Jy0q4vdG6pv76N92+X+ag3fuOV2zINQagYyMN1/es7tPI1vzpKECIU8AqHqzI6ahkwaph7XDvmfUkiLJ3i4LOA=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
@@ -1292,7 +1294,7 @@
 
     "@types/mssql": ["@types/mssql@12.3.0", "", { "dependencies": { "@types/node": "*", "tarn": "^3.0.1", "tedious": "*" } }, "sha512-+jy+AJtfuTDI5+nhh0hDNcir1p8P+pf+qsHXpUpYvg7EikxUUePBe+a+Kr6j/Xs89o4EbHlVzrh0HOxbqWM31Q=="],
 
-    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
@@ -1314,7 +1316,7 @@
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
-    "@types/three": ["@types/three@0.184.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA=="],
+    "@types/three": ["@types/three@0.185.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -1338,7 +1340,7 @@
 
     "@upstash/redis": ["@upstash/redis@1.37.0", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg=="],
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.5", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.5", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.5", "vitest": "4.1.5" }, "optionalPeers": ["@vitest/browser"] }, "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A=="],
 
@@ -1430,8 +1432,6 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
-    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
-
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -1480,10 +1480,6 @@
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
-    "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
-
-    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
-
     "chevrotain": ["chevrotain@12.0.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "12.0.0", "@chevrotain/gast": "12.0.0", "@chevrotain/regexp-to-ast": "12.0.0", "@chevrotain/types": "12.0.0", "@chevrotain/utils": "12.0.0" } }, "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ=="],
 
     "chevrotain-allstar": ["chevrotain-allstar@0.4.3", "", { "dependencies": { "lodash-es": "^4.18.1" }, "peerDependencies": { "chevrotain": "^12.0.0" } }, "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ=="],
@@ -1522,7 +1518,7 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "compute-scroll-into-view": ["compute-scroll-into-view@3.1.1", "", {}, "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="],
 
@@ -1554,11 +1550,7 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
-
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
-
-    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
@@ -1692,15 +1684,7 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
-    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
-
-    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
-
-    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
-
     "dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
-
-    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
@@ -1719,8 +1703,6 @@
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
-
-    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -1957,8 +1939,6 @@
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
-
-    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -2376,8 +2356,6 @@
 
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
 
-    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
-
     "nuqs": ["nuqs@2.8.9", "", { "dependencies": { "@standard-schema/spec": "1.0.0" }, "peerDependencies": { "@remix-run/react": ">=2", "@tanstack/react-router": "^1", "next": ">=14.2.0", "react": ">=18.2.0 || ^19.0.0-0", "react-router": "^5 || ^6 || ^7", "react-router-dom": "^5 || ^6 || ^7" }, "optionalPeers": ["@remix-run/react", "@tanstack/react-router", "next", "react-router", "react-router-dom"] }, "sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
@@ -2421,10 +2399,6 @@
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
     "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
-
-    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
-
-    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -2476,7 +2450,7 @@
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
-    "portless": ["portless@0.13.0", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-PxMZ5BHH+ZZi9rTq4T8m003aZxh56qI0aBdNsxLn7jrTtvNJYBWYD3lc5PuQrom/aVh6z8iLb+tKUI6b7QNYQw=="],
+    "portless": ["portless@0.14.0", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-kKxmxB1DQ9gI8t+V13VhuwTXu31io5nbFubvZAE82AxzXBsvcJV7qQJbmomrQUpbVxo2UVHqs14iX4YK0BClmQ=="],
 
     "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
 
@@ -2628,7 +2602,7 @@
 
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
 
-    "rolldown": ["rolldown@1.0.1", "", { "dependencies": { "@oxc-project/types": "=0.130.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.1", "@rolldown/binding-darwin-arm64": "1.0.1", "@rolldown/binding-darwin-x64": "1.0.1", "@rolldown/binding-freebsd-x64": "1.0.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.1", "@rolldown/binding-linux-arm64-gnu": "1.0.1", "@rolldown/binding-linux-arm64-musl": "1.0.1", "@rolldown/binding-linux-ppc64-gnu": "1.0.1", "@rolldown/binding-linux-s390x-gnu": "1.0.1", "@rolldown/binding-linux-x64-gnu": "1.0.1", "@rolldown/binding-linux-x64-musl": "1.0.1", "@rolldown/binding-openharmony-arm64": "1.0.1", "@rolldown/binding-wasm32-wasi": "1.0.1", "@rolldown/binding-win32-arm64-msvc": "1.0.1", "@rolldown/binding-win32-x64-msvc": "1.0.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ=="],
+    "rolldown": ["rolldown@1.1.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.4", "@rolldown/binding-darwin-arm64": "1.1.4", "@rolldown/binding-darwin-x64": "1.1.4", "@rolldown/binding-freebsd-x64": "1.1.4", "@rolldown/binding-linux-arm-gnueabihf": "1.1.4", "@rolldown/binding-linux-arm64-gnu": "1.1.4", "@rolldown/binding-linux-arm64-musl": "1.1.4", "@rolldown/binding-linux-ppc64-gnu": "1.1.4", "@rolldown/binding-linux-s390x-gnu": "1.1.4", "@rolldown/binding-linux-x64-gnu": "1.1.4", "@rolldown/binding-linux-x64-musl": "1.1.4", "@rolldown/binding-openharmony-arm64": "1.1.4", "@rolldown/binding-wasm32-wasi": "1.1.4", "@rolldown/binding-win32-arm64-msvc": "1.1.4", "@rolldown/binding-win32-x64-msvc": "1.1.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA=="],
 
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
 
@@ -2796,7 +2770,7 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
-    "three": ["three@0.184.0", "", {}, "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg=="],
+    "three": ["three@0.185.1", "", {}, "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
@@ -2864,7 +2838,7 @@
 
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
@@ -2920,7 +2894,7 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@8.0.13", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.1", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw=="],
+    "vite": ["vite@8.1.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.16", "rolldown": "~1.1.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA=="],
 
     "vite-tsconfig-paths": ["vite-tsconfig-paths@6.1.1", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" } }, "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg=="],
 
@@ -2953,8 +2927,6 @@
     "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
-
-    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
@@ -3034,7 +3006,11 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
-    "@db-studio/www/vite": ["vite@8.0.12", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg=="],
+    "@db-studio/www/@tanstack/react-router": ["@tanstack/react-router@1.170.16", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g=="],
+
+    "@db-studio/www/@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.2", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.0" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg=="],
+
+    "@db-studio/www/vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
 
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -3078,6 +3054,12 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "@storybook/csf-plugin/unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
 
     "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
@@ -3094,27 +3076,43 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@tanstack/ai-client/@tanstack/ai": ["@tanstack/ai@0.14.0", "", { "dependencies": { "@ag-ui/core": "0.0.49", "@tanstack/ai-event-client": "0.2.8", "partial-json": "^0.1.7" } }, "sha512-oiyYHcWMmyVoKDf018xZMEX62BaJVhdgeeRQeRbqP3p5Nvar2UZUhKzFkUiE4L9KzklPqrtI5aYhVdAp9Z142g=="],
+    "@tanstack/ai-client/@tanstack/ai": ["@tanstack/ai@0.39.1", "", { "dependencies": { "@ag-ui/core": "^0.0.52", "@standard-schema/spec": "^1.1.0", "@tanstack/ai-event-client": "0.6.8", "@tanstack/ai-utils": "0.3.1", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-lTmwGJ5/hzzr/qGuh56zuD7SjWiZu3jpOQMEEtgw6ImuWjQlsBdw5dKV+oykw3y9FzLLP1LlKb9gAHZ0OR2Fyg=="],
 
-    "@tanstack/ai-client/@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.2.8", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.14.0" } }, "sha512-pdvT1hh7UorwBiDLrXnI5BFDfc7JSqnN06LaQHG4TGRl/621UnUrh16hQKOMn/msArKiCj+n+TG+cw4mDwMaLw=="],
+    "@tanstack/ai-devtools-core/@tanstack/ai": ["@tanstack/ai@0.39.1", "", { "dependencies": { "@ag-ui/core": "^0.0.52", "@standard-schema/spec": "^1.1.0", "@tanstack/ai-event-client": "0.6.8", "@tanstack/ai-utils": "0.3.1", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-lTmwGJ5/hzzr/qGuh56zuD7SjWiZu3jpOQMEEtgw6ImuWjQlsBdw5dKV+oykw3y9FzLLP1LlKb9gAHZ0OR2Fyg=="],
 
-    "@tanstack/ai-devtools-core/@tanstack/ai": ["@tanstack/ai@0.14.0", "", { "dependencies": { "@ag-ui/core": "0.0.49", "@tanstack/ai-event-client": "0.2.8", "partial-json": "^0.1.7" } }, "sha512-oiyYHcWMmyVoKDf018xZMEX62BaJVhdgeeRQeRbqP3p5Nvar2UZUhKzFkUiE4L9KzklPqrtI5aYhVdAp9Z142g=="],
+    "@tanstack/ai-gemini/@tanstack/ai": ["@tanstack/ai@0.39.1", "", { "dependencies": { "@ag-ui/core": "^0.0.52", "@standard-schema/spec": "^1.1.0", "@tanstack/ai-event-client": "0.6.8", "@tanstack/ai-utils": "0.3.1", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-lTmwGJ5/hzzr/qGuh56zuD7SjWiZu3jpOQMEEtgw6ImuWjQlsBdw5dKV+oykw3y9FzLLP1LlKb9gAHZ0OR2Fyg=="],
 
-    "@tanstack/ai-devtools-core/@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.2.8", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.14.0" } }, "sha512-pdvT1hh7UorwBiDLrXnI5BFDfc7JSqnN06LaQHG4TGRl/621UnUrh16hQKOMn/msArKiCj+n+TG+cw4mDwMaLw=="],
+    "@tanstack/ai-react/@tanstack/ai": ["@tanstack/ai@0.39.1", "", { "dependencies": { "@ag-ui/core": "^0.0.52", "@standard-schema/spec": "^1.1.0", "@tanstack/ai-event-client": "0.6.8", "@tanstack/ai-utils": "0.3.1", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-lTmwGJ5/hzzr/qGuh56zuD7SjWiZu3jpOQMEEtgw6ImuWjQlsBdw5dKV+oykw3y9FzLLP1LlKb9gAHZ0OR2Fyg=="],
 
-    "@tanstack/ai-gemini/@tanstack/ai": ["@tanstack/ai@0.14.0", "", { "dependencies": { "@ag-ui/core": "0.0.49", "@tanstack/ai-event-client": "0.2.8", "partial-json": "^0.1.7" } }, "sha512-oiyYHcWMmyVoKDf018xZMEX62BaJVhdgeeRQeRbqP3p5Nvar2UZUhKzFkUiE4L9KzklPqrtI5aYhVdAp9Z142g=="],
+    "@tanstack/devtools/@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.6", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" } }, "sha512-f85ZJXJnDIFOoykG/BFIixuAevJovCvJF391LPs6YjBAPhGYC50NWlx1y4iF/UmK5/cCMx+/JqI5SBOz7FanQQ=="],
 
-    "@tanstack/ai-react/@tanstack/ai": ["@tanstack/ai@0.14.0", "", { "dependencies": { "@ag-ui/core": "0.0.49", "@tanstack/ai-event-client": "0.2.8", "partial-json": "^0.1.7" } }, "sha512-oiyYHcWMmyVoKDf018xZMEX62BaJVhdgeeRQeRbqP3p5Nvar2UZUhKzFkUiE4L9KzklPqrtI5aYhVdAp9Z142g=="],
+    "@tanstack/devtools/@tanstack/devtools-event-bus": ["@tanstack/devtools-event-bus@0.4.1", "", { "dependencies": { "ws": "^8.18.3" } }, "sha512-cNnJ89Q021Zf883rlbBTfsaxTfi2r73/qejGtyTa7ksErF3hyDyAq1aTbo5crK9dAL7zSHh9viKY1BtMls1QOA=="],
 
-    "@tanstack/devtools/@tanstack/devtools-ui": ["@tanstack/devtools-ui@0.5.2", "", { "dependencies": { "clsx": "^2.1.1", "dayjs": "^1.11.19", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-GtaMk8kaGZ9ZdR8Pu5RAfcse/ZrxzH/xsAIFtHMapLs2VMqSPFfb1NvIDO1MAAfUcub8Ix8XKQEP0uYSPzoFKw=="],
+    "@tanstack/devtools-client/@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.5.0", "", { "bin": { "intent": "./bin/intent.js" } }, "sha512-H+OH3zC6Vhu/K0NaVfQKknEKawc/+2PT+D3SB3Ox0V8SiMlTo0abbmH2rH0721R2aNYbjdMXA1oENOd8E2UVoA=="],
 
-    "@tanstack/react-router/@tanstack/router-core": ["@tanstack/router-core@1.171.0", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-40RHf0YtI+Zf4M672G+r//N+o7SODzEByI8AgM/z+VNFmVwW7K+qbulOrh/xuzMclhAcm4WuIXhtvfWz/p2FAQ=="],
+    "@tanstack/devtools-vite/oxc-parser": ["oxc-parser@0.120.0", "", { "dependencies": { "@oxc-project/types": "^0.120.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.120.0", "@oxc-parser/binding-android-arm64": "0.120.0", "@oxc-parser/binding-darwin-arm64": "0.120.0", "@oxc-parser/binding-darwin-x64": "0.120.0", "@oxc-parser/binding-freebsd-x64": "0.120.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.120.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.120.0", "@oxc-parser/binding-linux-arm64-gnu": "0.120.0", "@oxc-parser/binding-linux-arm64-musl": "0.120.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.120.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.120.0", "@oxc-parser/binding-linux-riscv64-musl": "0.120.0", "@oxc-parser/binding-linux-s390x-gnu": "0.120.0", "@oxc-parser/binding-linux-x64-gnu": "0.120.0", "@oxc-parser/binding-linux-x64-musl": "0.120.0", "@oxc-parser/binding-openharmony-arm64": "0.120.0", "@oxc-parser/binding-wasm32-wasi": "0.120.0", "@oxc-parser/binding-win32-arm64-msvc": "0.120.0", "@oxc-parser/binding-win32-ia32-msvc": "0.120.0", "@oxc-parser/binding-win32-x64-msvc": "0.120.0" } }, "sha512-WyPWZlcIm+Fkte63FGfgFB8mAAk33aH9h5N9lphXVOHSXEBFFsmYdOBedVKly363aWABjZdaj/m9lBfEY4wt+w=="],
 
-    "@tanstack/react-start-client/@tanstack/router-core": ["@tanstack/router-core@1.171.0", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-40RHf0YtI+Zf4M672G+r//N+o7SODzEByI8AgM/z+VNFmVwW7K+qbulOrh/xuzMclhAcm4WuIXhtvfWz/p2FAQ=="],
+    "@tanstack/react-ai-devtools/@tanstack/ai-devtools-core": ["@tanstack/ai-devtools-core@0.3.25", "", { "dependencies": { "@tanstack/ai": "0.14.0", "@tanstack/ai-event-client": "0.2.8", "@tanstack/devtools-ui": "^0.5.1", "@tanstack/devtools-utils": "^0.4.0", "goober": "^2.1.18", "solid-js": "^1.9.10" } }, "sha512-nu7OtdCF1a86aRXVQEMU5Z30WcFuAbgjWvD7WtFJl73T0CiM+8bCywYE9giaw8kR42+EZ8eUzE2tUV2TI0JrtQ=="],
 
-    "@tanstack/react-start-rsc/@tanstack/router-core": ["@tanstack/router-core@1.171.0", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-40RHf0YtI+Zf4M672G+r//N+o7SODzEByI8AgM/z+VNFmVwW7K+qbulOrh/xuzMclhAcm4WuIXhtvfWz/p2FAQ=="],
+    "@tanstack/react-router/@tanstack/router-core": ["@tanstack/router-core@1.171.14", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-Mo3hwx0qB0cJsVYGDjG0+Ouf7VV74h/vsoDMGztdlyzDanp4gBA2s7IVvm6hFrmQM6GpD9F0Z7SqD7OldfLE7g=="],
 
-    "@tanstack/react-start-server/@tanstack/router-core": ["@tanstack/router-core@1.171.0", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-40RHf0YtI+Zf4M672G+r//N+o7SODzEByI8AgM/z+VNFmVwW7K+qbulOrh/xuzMclhAcm4WuIXhtvfWz/p2FAQ=="],
+    "@tanstack/react-start/@tanstack/react-router": ["@tanstack/react-router@1.170.16", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g=="],
+
+    "@tanstack/react-start/@tanstack/router-utils": ["@tanstack/router-utils@1.162.2", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ=="],
+
+    "@tanstack/react-start-client/@tanstack/react-router": ["@tanstack/react-router@1.170.16", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g=="],
+
+    "@tanstack/react-start-client/@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
+
+    "@tanstack/react-start-rsc/@tanstack/react-router": ["@tanstack/react-router@1.170.16", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g=="],
+
+    "@tanstack/react-start-rsc/@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
+
+    "@tanstack/react-start-rsc/@tanstack/router-utils": ["@tanstack/router-utils@1.162.2", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ=="],
+
+    "@tanstack/react-start-server/@tanstack/react-router": ["@tanstack/react-router@1.170.16", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g=="],
+
+    "@tanstack/react-start-server/@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
 
     "@tanstack/router-core/@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
 
@@ -3128,29 +3126,43 @@
 
     "@tanstack/router-plugin/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@tanstack/start-client-core/@tanstack/router-core": ["@tanstack/router-core@1.171.0", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-40RHf0YtI+Zf4M672G+r//N+o7SODzEByI8AgM/z+VNFmVwW7K+qbulOrh/xuzMclhAcm4WuIXhtvfWz/p2FAQ=="],
+    "@tanstack/start-client-core/@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
 
     "@tanstack/start-client-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
-    "@tanstack/start-plugin-core/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.40", "", {}, "sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w=="],
+    "@tanstack/start-plugin-core/@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
 
-    "@tanstack/start-plugin-core/@tanstack/router-core": ["@tanstack/router-core@1.171.0", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-40RHf0YtI+Zf4M672G+r//N+o7SODzEByI8AgM/z+VNFmVwW7K+qbulOrh/xuzMclhAcm4WuIXhtvfWz/p2FAQ=="],
+    "@tanstack/start-plugin-core/@tanstack/router-generator": ["@tanstack/router-generator@1.167.17", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.13", "@tanstack/router-utils": "1.162.2", "@tanstack/virtual-file-routes": "1.162.0", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^4.4.3" } }, "sha512-xtB9tB2Ws0tWR6Pi7nc3Qk9IYgoh1mQCKWjHqIl9tf6BNUpKoqniJoPAQ4+LGrK8FeZYU0o0p/qlZEyj9FAulA=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin": ["@tanstack/router-plugin@1.168.18", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.13", "@tanstack/router-generator": "1.167.17", "@tanstack/router-utils": "1.162.2", "chokidar": "^5.0.0", "unplugin": "^3.0.0", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.170.15", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"] }, "sha512-MofS28/axfnfnhOD2RSgJEaU882aX5RsAzhGz5Vc4XhAmvCjy919u9JrNs4QsTWFbTD1P7IJ8WFlFVsrg0pStg=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-utils": ["@tanstack/router-utils@1.162.2", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ=="],
 
     "@tanstack/start-plugin-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
-    "@tanstack/start-plugin-core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "@tanstack/start-plugin-core/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
-    "@tanstack/start-server-core/@tanstack/router-core": ["@tanstack/router-core@1.171.0", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-40RHf0YtI+Zf4M672G+r//N+o7SODzEByI8AgM/z+VNFmVwW7K+qbulOrh/xuzMclhAcm4WuIXhtvfWz/p2FAQ=="],
+    "@tanstack/start-server-core/@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
 
     "@tanstack/start-server-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
-    "@tanstack/start-storage-context/@tanstack/router-core": ["@tanstack/router-core@1.171.0", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-40RHf0YtI+Zf4M672G+r//N+o7SODzEByI8AgM/z+VNFmVwW7K+qbulOrh/xuzMclhAcm4WuIXhtvfWz/p2FAQ=="],
+    "@tanstack/start-storage-context/@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "@types/better-sqlite3/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/mssql/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/pg/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/readable-stream/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/set-cookie-parser/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/three/fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
@@ -3168,9 +3180,7 @@
 
     "ast-v8-to-istanbul/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
-    "cheerio/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
-    "cheerio/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+    "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "cmdk/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
@@ -3186,23 +3196,15 @@
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
-    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
-
-    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
-
     "estree-util-build-jsx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "fumadocs-mdx/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "fumadocs-mdx/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
-    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -3228,11 +3230,9 @@
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
+    "nuqs/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
-
-    "parse5-htmlparser2-tree-adapter/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
-    "parse5-parser-stream/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
@@ -3241,6 +3241,8 @@
     "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "protobufjs/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
@@ -3252,11 +3254,13 @@
 
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
-    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+    "rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "shadcn/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -3270,13 +3274,17 @@
 
     "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
+    "tedious/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "tsup/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "tsup/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "vite/postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+    "vite/postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "vitest/@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
 
@@ -3284,15 +3292,17 @@
 
     "vitest/vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 
-    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
-
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@azure/identity/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
-    "@db-studio/www/vite/postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+    "@db-studio/www/@tanstack/react-router/@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
 
-    "@db-studio/www/vite/rolldown": ["rolldown@1.0.0", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@rolldown/pluginutils": "1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0", "@rolldown/binding-darwin-arm64": "1.0.0", "@rolldown/binding-darwin-x64": "1.0.0", "@rolldown/binding-freebsd-x64": "1.0.0", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0", "@rolldown/binding-linux-arm64-gnu": "1.0.0", "@rolldown/binding-linux-arm64-musl": "1.0.0", "@rolldown/binding-linux-ppc64-gnu": "1.0.0", "@rolldown/binding-linux-s390x-gnu": "1.0.0", "@rolldown/binding-linux-x64-gnu": "1.0.0", "@rolldown/binding-linux-x64-musl": "1.0.0", "@rolldown/binding-openharmony-arm64": "1.0.0", "@rolldown/binding-wasm32-wasi": "1.0.0", "@rolldown/binding-win32-arm64-msvc": "1.0.0", "@rolldown/binding-win32-x64-msvc": "1.0.0" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA=="],
+    "@db-studio/www/vite/postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+
+    "@db-studio/www/vite/rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+
+    "@db-studio/www/vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
@@ -3306,9 +3316,57 @@
 
     "@dotenvx/dotenvx/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
-    "@tanstack/ai-gemini/@tanstack/ai/@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.2.8", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.14.0" } }, "sha512-pdvT1hh7UorwBiDLrXnI5BFDfc7JSqnN06LaQHG4TGRl/621UnUrh16hQKOMn/msArKiCj+n+TG+cw4mDwMaLw=="],
+    "@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
-    "@tanstack/ai-react/@tanstack/ai/@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.2.8", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.14.0" } }, "sha512-pdvT1hh7UorwBiDLrXnI5BFDfc7JSqnN06LaQHG4TGRl/621UnUrh16hQKOMn/msArKiCj+n+TG+cw4mDwMaLw=="],
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.120.0", "", { "os": "android", "cpu": "arm" }, "sha512-WU3qtINx802wOl8RxAF1v0VvmC2O4D9M8Sv486nLeQ7iPHVmncYZrtBhB4SYyX+XZxj2PNnCcN+PW21jHgiOxg=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.120.0", "", { "os": "android", "cpu": "arm64" }, "sha512-SEf80EHdhlbjZEgzeWm0ZA/br4GKMenDW3QB/gtyeTV1gStvvZeFi40ioHDZvds2m4Z9J1bUAUL8yn1/+A6iGg=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.120.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xVrrbCai8R8CUIBu3CjryutQnEYhZqs1maIqDvtUCFZb8vY33H7uh9mHpL3a0JBIKoBUKjPH8+rzyAeXnS2d6A=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.120.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-xyHBbnJ6mydnQUH7MAcafOkkrNzQC6T+LXgDH/3InEq2BWl/g424IMRiJVSpVqGjB+p2bd0h0WRR8iIwzjU7rw=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.120.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMnVRllquXUYTeNfFKmxTTEdZ/ix1nLl0ducDzMSREoWYGVIHnOOxoKMWlCOvRr9Wk/HZqo2rh1jeumbPGPV9A=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.120.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tkvn2CQ7QdcsMnpfiX3fd3wA3EFsWKYlcQzq9cFw/xc89Al7W6Y4O0FgLVkVQpo0Tnq/qtE1XfkJOnRRA9S/NA=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.120.0", "", { "os": "linux", "cpu": "arm" }, "sha512-WN5y135Ic42gQDk9grbwY9++fDhqf8knN6fnP+0WALlAUh4odY/BDK1nfTJRSfpJD9P3r1BwU0m3pW2DU89whQ=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.120.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-1GgQBCcXvFMw99EPdMy+4NZ3aYyXsxjf9kbUUg8HuAy3ZBXzOry5KfFEzT9nqmgZI1cuetvApkiJBZLAPo8uaw=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.120.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-gmMQ70gsPdDBgpcErvJEoWNBr7bJooSLlvOBVBSGfOzlP5NvJ3bFvnUeZZ9d+dPrqSngtonf7nyzWUTUj/U+lw=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.120.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-T/kZuU0ajop0xhzVMwH5r3srC9Nqup5HaIo+3uFjIN5uPxa0LvSxC1ZqP4aQGJVW5G0z8/nCkjIfSMS91P/wzw=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.120.0", "", { "os": "linux", "cpu": "none" }, "sha512-vn21KXLAXzaI3N5CZWlBr1iWeXLl9QFIMor7S1hUjUGTeUuWCoE6JZB040/ZNDwf+JXPX8Ao9KbmJq9FMC2iGw=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.120.0", "", { "os": "linux", "cpu": "none" }, "sha512-SUbUxlar007LTGmSLGIC5x/WJvwhdX+PwNzFJ9f/nOzZOrCFbOT4ikt7pJIRg1tXVsEfzk5mWpGO1NFiSs4PIw=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.120.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hYiPJTxyfJY2+lMBFk3p2bo0R9GN+TtpPFlRqVchL1qvLG+pznstramHNvJlw9AjaoRUHwp9IKR7UZQnRPGjgQ=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.120.0", "", { "os": "linux", "cpu": "x64" }, "sha512-q+5jSVZkprJCIy3dzJpApat0InJaoxQLsJuD6DkX8hrUS61z2lHQ1Fe9L2+TYbKHXCLWbL0zXe7ovkIdopBGMQ=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.120.0", "", { "os": "linux", "cpu": "x64" }, "sha512-D9QDDZNnH24e7X4ftSa6ar/2hCavETfW3uk0zgcMIrZNy459O5deTbWrjGzZiVrSWigGtlQwzs2McBP0QsfV1w=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.120.0", "", { "os": "none", "cpu": "arm64" }, "sha512-TBU8ZwOUWAOUWVfmI16CYWbvh4uQb9zHnGBHsw5Cp2JUVG044OIY1CSHODLifqzQIMTXvDvLzcL89GGdUIqNrA=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.120.0", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-WG/FOZgDJCpJnuF3ToG/K28rcOmSY7FmFmfBKYb2fmLyhDzPpUldFGV7/Fz4ru0Iz/v4KPmf8xVgO8N3lO4KHA=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.120.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1T0HKGcsz/BKo77t7+89L8Qvu4f9DoleKWHp3C5sJEcbCjDOLx3m9m722bWZTY+hANlUEs+yjlK+lBFsA+vrVQ=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.120.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-L7vfLzbOXsjBXV0rv/6Y3Jd9BRjPeCivINZAqrSyAOZN3moCopDN+Psq9ZrGNZtJzP8946MtlRFZ0Als0wBCOw=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.120.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ys+upfqNtSu58huAhJMBKl3XCkGzyVFBlMlGPzHeFKgpFF/OdgNs1MMf8oaJIbgMH8ZxgGF7qfue39eJohmKIg=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-project/types": ["@oxc-project/types@0.120.0", "", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
+
+    "@tanstack/react-ai-devtools/@tanstack/ai-devtools-core/@tanstack/ai": ["@tanstack/ai@0.14.0", "", { "dependencies": { "@ag-ui/core": "0.0.49", "@tanstack/ai-event-client": "0.2.8", "partial-json": "^0.1.7" } }, "sha512-oiyYHcWMmyVoKDf018xZMEX62BaJVhdgeeRQeRbqP3p5Nvar2UZUhKzFkUiE4L9KzklPqrtI5aYhVdAp9Z142g=="],
+
+    "@tanstack/react-ai-devtools/@tanstack/ai-devtools-core/@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.2.8", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.14.0" } }, "sha512-pdvT1hh7UorwBiDLrXnI5BFDfc7JSqnN06LaQHG4TGRl/621UnUrh16hQKOMn/msArKiCj+n+TG+cw4mDwMaLw=="],
+
+    "@tanstack/react-ai-devtools/@tanstack/ai-devtools-core/@tanstack/devtools-ui": ["@tanstack/devtools-ui@0.5.1", "", { "dependencies": { "clsx": "^2.1.1", "dayjs": "^1.11.19", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-T9JjAdqMSnxsVO6AQykD5vhxPF4iFLKtbYxee/bU3OLlk446F5C1220GdCmhDSz7y4lx+m8AvIS0bq6zzvdDUA=="],
 
     "@tanstack/react-router/@tanstack/router-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
@@ -3322,9 +3380,15 @@
 
     "@tanstack/react-start-rsc/@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
 
+    "@tanstack/react-start-rsc/@tanstack/router-utils/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "@tanstack/react-start-server/@tanstack/router-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
     "@tanstack/react-start-server/@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
+
+    "@tanstack/react-start/@tanstack/react-router/@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
+
+    "@tanstack/react-start/@tanstack/router-utils/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "@tanstack/router-devtools-core/@tanstack/router-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
@@ -3344,17 +3408,29 @@
 
     "@tanstack/start-plugin-core/@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
 
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
     "@tanstack/start-server-core/@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
 
     "@tanstack/start-storage-context/@tanstack/router-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
     "@tanstack/start-storage-context/@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
 
+    "@types/better-sqlite3/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@types/mssql/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@types/pg/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@types/readable-stream/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@types/set-cookie-parser/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
     "@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "cheerio/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -3380,9 +3456,7 @@
 
     "msw/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "parse5-htmlparser2-tree-adapter/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "parse5-parser-stream/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "protobufjs/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -3390,53 +3464,65 @@
 
     "tar-stream/bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
+    "tedious/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
     "tsup/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "vite/postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
-    "vitest/@vitest/expect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "vitest/vite/rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
+    "@db-studio/www/@tanstack/react-router/@tanstack/router-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
+
+    "@db-studio/www/@tanstack/react-router/@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
+
     "@db-studio/www/vite/postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
-    "@db-studio/www/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+    "@db-studio/www/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0", "", { "os": "android", "cpu": "arm64" }, "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0", "", { "os": "linux", "cpu": "arm" }, "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0", "", { "os": "none", "cpu": "arm64" }, "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.3", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg=="],
+    "@db-studio/www/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="],
 
-    "@db-studio/www/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0", "", {}, "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ=="],
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@tanstack/react-ai-devtools/@tanstack/ai-devtools-core/@tanstack/ai/@ag-ui/core": ["@ag-ui/core@0.0.49", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-9ywypwjUGtIvTxJ2eKQjhPZgLnSFAfNK7vZUcT7Bz4ur4yAIB+lAFtzvu7VDYe6jsUx/6N/71Dh4R0zX5woNVw=="],
+
+    "@tanstack/react-start/@tanstack/react-router/@tanstack/router-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
+
+    "@tanstack/react-start/@tanstack/react-router/@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "msw/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -3480,10 +3566,18 @@
 
     "vitest/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 
+    "@db-studio/www/vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@tanstack/react-ai-devtools/@tanstack/ai-devtools-core/@tanstack/ai/@ag-ui/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "msw/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "msw/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "msw/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@db-studio/www/vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
   }
 }

--- a/packages/server/src/utils/create-server.ts
+++ b/packages/server/src/utils/create-server.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { DEFAULTS } from "@db-studio/shared/constants";
 import type { DatabaseTypeSchema } from "@db-studio/shared/types";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { zValidator } from "@hono/zod-validator";
@@ -19,6 +20,8 @@ import { databasesRoutes } from "@/routes/databases.routes.js";
 import { queryRoutes } from "@/routes/query.routes.js";
 import { recordsRoutes } from "@/routes/records.routes.js";
 import { tablesRoutes } from "@/routes/tables.routes.js";
+
+const { API_PREFIX } = DEFAULTS;
 
 /**
  * Get the path to the web app distribution directory.
@@ -101,22 +104,27 @@ export const createServer = () => {
 		.onError(handleError)
 
 		/**
-		 * Database routes - available at root level (no dbType required)
+		 * API routes are namespaced under API_PREFIX so they never collide with
+		 * client-side (SPA) routes served from the same origin. A refresh on a
+		 * client route like `/table/:name` must fall through to index.html, not
+		 * be interpreted as a `/:dbType/...` API request. See db-studio#214.
+		 *
+		 * Database routes - available at the API root (no dbType required)
 		 */
-		.route("/", databasesRoutes)
-		.route("/", chatRoutes)
+		.route(API_PREFIX, databasesRoutes)
+		.route(API_PREFIX, chatRoutes)
 
 		/**
-		 * Serve static assets (before dbType validation to avoid conflicts)
+		 * Serve static assets (SPA-owned; live at the root, not under the API prefix)
 		 */
 		.use("/assets/*", serveStatic({ root: getWebDistPath() }))
 		.use("/image.png", serveStatic({ root: getWebDistPath() }))
 
 		/**
-		 * Routes that require dbType validation - under /:dbType/...
+		 * Routes that require dbType validation - under API_PREFIX/:dbType/...
 		 */
 		.use(
-			"/:dbType/*",
+			`${API_PREFIX}/:dbType/*`,
 			zValidator("param", databaseTypeParamSchema, (result, c) => {
 				if (!result.success) {
 					const rawType = c.req.param("dbType");
@@ -131,11 +139,21 @@ export const createServer = () => {
 				await next();
 			},
 		)
-		.route("/:dbType", tablesRoutes)
-		.route("/:dbType", recordsRoutes)
-		.route("/:dbType", queryRoutes);
+		.route(`${API_PREFIX}/:dbType`, tablesRoutes)
+		.route(`${API_PREFIX}/:dbType`, recordsRoutes)
+		.route(`${API_PREFIX}/:dbType`, queryRoutes);
 
 	if (process.env.NODE_ENV !== "test") {
+		/**
+		 * Any unmatched API path is a genuine 404 - respond with JSON so API
+		 * clients never receive the SPA's index.html HTML by mistake.
+		 */
+		app.all(`${API_PREFIX}/*`, (c) => c.json({ error: "Not found" }, 404));
+
+		/**
+		 * SPA fallback - every non-API path serves the client app so that
+		 * deep-link refreshes (e.g. /table/:name) load index.html.
+		 */
 		app.use("/*", serveStatic({ root: getWebDistPath() }));
 		app.get("/*", serveStatic({ path: path.resolve(getWebDistPath(), "index.html") }));
 	}

--- a/packages/server/tests/http/databases.http
+++ b/packages/server/tests/http/databases.http
@@ -1,8 +1,8 @@
 ### Database API Endpoints
-### Base URL: http://localhost:3333/:dbType
+### Base URL: http://localhost:3333/api/:dbType
 ### Replace :dbType with 'pg' for PostgreSQL or 'mysql' for MySQL
 
-@baseUrl = http://localhost:3333/pg
+@baseUrl = http://localhost:3333/api/pg
 
 ### ============================================
 ### GET /databases - List all databases

--- a/packages/server/tests/http/query.http
+++ b/packages/server/tests/http/query.http
@@ -1,8 +1,8 @@
 ### Query API Endpoints
-### Base URL: http://localhost:3333/:dbType
+### Base URL: http://localhost:3333/api/:dbType
 ### Replace :dbType with 'pg' for PostgreSQL
 
-@baseUrl = http://localhost:3333/pg
+@baseUrl = http://localhost:3333/api/pg
 @database = flowx
 
 ### ============================================
@@ -525,7 +525,7 @@ Content-Type: application/json
 ### ============================================
 
 ### Invalid database type (should return 400)
-POST http://localhost:3333/invalid/query?database={{database}}
+POST http://localhost:3333/api/invalid/query?database={{database}}
 Content-Type: application/json
 
 {
@@ -535,7 +535,7 @@ Content-Type: application/json
 ###
 
 ### MySQL database type - not supported (should return 400)
-POST http://localhost:3333/mysql/query?database={{database}}
+POST http://localhost:3333/api/mysql/query?database={{database}}
 Content-Type: application/json
 
 {
@@ -545,7 +545,7 @@ Content-Type: application/json
 ###
 
 ### SQLite database type - not supported (should return 400)
-POST http://localhost:3333/sqlite/query?database={{database}}
+POST http://localhost:3333/api/sqlite/query?database={{database}}
 Content-Type: application/json
 
 {

--- a/packages/server/tests/http/records.http
+++ b/packages/server/tests/http/records.http
@@ -1,8 +1,8 @@
 ### Records API Endpoints
-### Base URL: http://localhost:3333/:dbType
+### Base URL: http://localhost:3333/api/:dbType
 ### Replace :dbType with 'pg' for PostgreSQL
 
-@baseUrl = http://localhost:3333/pg
+@baseUrl = http://localhost:3333/api/pg
 @database = postgres
 
 ### ============================================
@@ -605,7 +605,7 @@ Content-Type: application/json
 ### ============================================
 
 ### Invalid database type on POST (should return 400)
-POST http://localhost:3333/invalid/records?database={{database}}
+POST http://localhost:3333/api/invalid/records?database={{database}}
 Content-Type: application/json
 
 {
@@ -616,7 +616,7 @@ Content-Type: application/json
 ###
 
 ### MySQL database type on PATCH - not supported (should return 400)
-PATCH http://localhost:3333/mysql/records?database={{database}}
+PATCH http://localhost:3333/api/mysql/records?database={{database}}
 Content-Type: application/json
 
 {
@@ -634,7 +634,7 @@ Content-Type: application/json
 ###
 
 ### SQLite database type on DELETE - not supported (should return 400)
-DELETE http://localhost:3333/sqlite/records?database={{database}}
+DELETE http://localhost:3333/api/sqlite/records?database={{database}}
 Content-Type: application/json
 
 {

--- a/packages/server/tests/http/tables.http
+++ b/packages/server/tests/http/tables.http
@@ -1,8 +1,8 @@
 ### Tables API Endpoints
-### Base URL: http://localhost:3333/:dbType
+### Base URL: http://localhost:3333/api/:dbType
 ### Replace :dbType with 'pg' for PostgreSQL
 
-@baseUrl = http://localhost:3333/pg
+@baseUrl = http://localhost:3333/api/pg
 @database = flowx
 @tableName = user
 
@@ -406,19 +406,19 @@ Content-Type: application/json
 ### ============================================
 
 ### Invalid database type (should return 400)
-GET http://localhost:3333/invalid/tables?database={{database}}
+GET http://localhost:3333/api/invalid/tables?database={{database}}
 Content-Type: application/json
 
 ###
 
 ### MySQL database type - not supported (should return 400)
-GET http://localhost:3333/mysql/tables?database={{database}}
+GET http://localhost:3333/api/mysql/tables?database={{database}}
 Content-Type: application/json
 
 ###
 
 ### SQLite database type - not supported (should return 400)
-GET http://localhost:3333/sqlite/tables?database={{database}}
+GET http://localhost:3333/api/sqlite/tables?database={{database}}
 Content-Type: application/json
 
 ### ============================================

--- a/packages/server/tests/routes/databases.routes.test.ts
+++ b/packages/server/tests/routes/databases.routes.test.ts
@@ -68,7 +68,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getDatabasesList.mockResolvedValue(mockDatabases);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -80,7 +80,7 @@ describe("Databases Routes", () => {
 		it("should return empty array when no databases exist", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -94,7 +94,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getDatabasesList.mockResolvedValue(mockDatabases);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -112,7 +112,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getDatabasesList.mockResolvedValue(mockDatabases);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -127,7 +127,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getDatabasesList.mockResolvedValue(mockDatabases);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -145,7 +145,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getDatabasesList.mockResolvedValue(mockDatabases);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -161,7 +161,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getDatabasesList.mockResolvedValue(mockDatabases);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -177,7 +177,7 @@ describe("Databases Routes", () => {
 				new HTTPException(500, { message: "No databases returned from database" }),
 			);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(500);
 		});
@@ -186,7 +186,7 @@ describe("Databases Routes", () => {
 			const connectionError = new Error("connect ECONNREFUSED 127.0.0.1:5432");
 			mockDao.getDatabasesList.mockRejectedValue(connectionError);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(503);
 			const json = await res.json();
@@ -197,7 +197,7 @@ describe("Databases Routes", () => {
 			const timeoutError = new Error("timeout expired");
 			mockDao.getDatabasesList.mockRejectedValue(timeoutError);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(503);
 			const json = await res.json();
@@ -208,7 +208,7 @@ describe("Databases Routes", () => {
 			const terminatedError = new Error("Connection terminated unexpectedly");
 			mockDao.getDatabasesList.mockRejectedValue(terminatedError);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(503);
 		});
@@ -217,7 +217,7 @@ describe("Databases Routes", () => {
 			const dbError = new Error("Unexpected database error");
 			mockDao.getDatabasesList.mockRejectedValue(dbError);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(500);
 			const json = await res.json();
@@ -231,7 +231,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getCurrentDatabase.mockResolvedValue(mockCurrent);
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -246,7 +246,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getCurrentDatabase.mockResolvedValue(mockCurrent);
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -258,7 +258,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getCurrentDatabase.mockResolvedValue(mockCurrent);
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -270,7 +270,7 @@ describe("Databases Routes", () => {
 				new HTTPException(500, { message: "No current database returned from database" }),
 			);
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(500);
 		});
@@ -278,7 +278,7 @@ describe("Databases Routes", () => {
 		it("should return 503 on connection error", async () => {
 			mockDao.getCurrentDatabase.mockRejectedValue(new Error("connection refused"));
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(503);
 		});
@@ -298,7 +298,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockConnectionInfo);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -319,7 +319,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockConnectionInfo);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -340,7 +340,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockConnectionInfo);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -370,7 +370,7 @@ describe("Databases Routes", () => {
 
 				mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockConnectionInfo);
 
-				const res = await app.request("/databases/connection");
+				const res = await app.request("/api/databases/connection");
 
 				expect(res.status).toBe(200);
 				const json = await res.json();
@@ -391,7 +391,7 @@ describe("Databases Routes", () => {
 
 			mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockConnectionInfo);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -403,7 +403,7 @@ describe("Databases Routes", () => {
 				new HTTPException(500, { message: "No connection information returned from database" }),
 			);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(500);
 		});
@@ -413,7 +413,7 @@ describe("Databases Routes", () => {
 				new Error("connect ECONNREFUSED"),
 			);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(503);
 		});
@@ -421,19 +421,19 @@ describe("Databases Routes", () => {
 
 	describe("Invalid database type validation", () => {
 		it("should return 400 for invalid database type", async () => {
-			const res = await app.request("/invalid/databases");
+			const res = await app.request("/api/invalid/databases");
 
 			expect(res.status).toBe(400);
 		});
 
 		it("should return 404 for /mysql/databases (no dbType-prefixed databases route)", async () => {
-			const res = await app.request("/mysql/databases");
+			const res = await app.request("/api/mysql/databases");
 
 			expect(res.status).toBe(404);
 		});
 
 		it("should return 400 for sqlite database type (not supported)", async () => {
-			const res = await app.request("/sqlite/databases");
+			const res = await app.request("/api/sqlite/databases");
 
 			expect(res.status).toBe(400);
 		});
@@ -445,7 +445,7 @@ describe("Databases Routes", () => {
 		});
 
 		it("should return 400 for numeric database type", async () => {
-			const res = await app.request("/123/databases");
+			const res = await app.request("/api/123/databases");
 
 			expect(res.status).toBe(400);
 		});
@@ -453,7 +453,7 @@ describe("Databases Routes", () => {
 		it("should accept valid pg database type", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 		});
@@ -461,38 +461,38 @@ describe("Databases Routes", () => {
 
 	describe("HTTP methods validation", () => {
 		it("should reject POST /databases", async () => {
-			const res = await app.request("/databases", { method: "POST" });
+			const res = await app.request("/api/databases", { method: "POST" });
 
 			expect([404, 405, 400]).toContain(res.status);
 		});
 
 		it("should reject PUT /databases", async () => {
-			const res = await app.request("/databases", { method: "PUT" });
+			const res = await app.request("/api/databases", { method: "PUT" });
 
 			expect([404, 405, 400]).toContain(res.status);
 		});
 
 		it("should reject DELETE /databases", async () => {
-			const res = await app.request("/databases", { method: "DELETE" });
+			const res = await app.request("/api/databases", { method: "DELETE" });
 
 			expect([404, 405, 400]).toContain(res.status);
 		});
 
 		it("should reject PATCH /databases", async () => {
-			const res = await app.request("/databases", { method: "PATCH" });
+			const res = await app.request("/api/databases", { method: "PATCH" });
 
 			expect([404, 405, 400]).toContain(res.status);
 		});
 
 		it("should handle OPTIONS request for CORS", async () => {
-			const res = await app.request("/databases", { method: "OPTIONS" });
+			const res = await app.request("/api/databases", { method: "OPTIONS" });
 
 			expect([200, 204, 404]).toContain(res.status);
 		});
 
 		it("should return 404 for HEAD /databases", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
-			const res = await app.request("/databases", { method: "HEAD" });
+			const res = await app.request("/api/databases", { method: "HEAD" });
 
 			expect([200, 404]).toContain(res.status);
 		});
@@ -502,7 +502,7 @@ describe("Databases Routes", () => {
 		it("should include CORS headers", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
 		});
@@ -510,7 +510,7 @@ describe("Databases Routes", () => {
 		it("should return JSON content type", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.headers.get("Content-Type")).toContain("application/json");
 		});
@@ -522,7 +522,7 @@ describe("Databases Routes", () => {
 				{ name: "testdb", size: "1 MB", owner: "user", encoding: "UTF8" },
 			]);
 
-			const requests = Array.from({ length: 10 }, () => app.request("/databases"));
+			const requests = Array.from({ length: 10 }, () => app.request("/api/databases"));
 
 			const responses = await Promise.all(requests);
 
@@ -547,9 +547,9 @@ describe("Databases Routes", () => {
 			});
 
 			const [res1, res2, res3] = await Promise.all([
-				app.request("/databases"),
-				app.request("/databases/current"),
-				app.request("/databases/connection"),
+				app.request("/api/databases"),
+				app.request("/api/databases/current"),
+				app.request("/api/databases/connection"),
 			]);
 
 			expect(res1.status).toBe(200);
@@ -562,7 +562,7 @@ describe("Databases Routes", () => {
 		it("should handle trailing slash in URL", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases/");
+			const res = await app.request("/api/databases/");
 
 			expect([200, 404]).toContain(res.status);
 		});
@@ -570,25 +570,25 @@ describe("Databases Routes", () => {
 		it("should handle query parameters gracefully", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases?foo=bar&baz=123");
+			const res = await app.request("/api/databases?foo=bar&baz=123");
 
 			expect(res.status).toBe(200);
 		});
 
 		it("should handle URL encoded characters", async () => {
-			const res = await app.request("/databases%2Fcurrent");
+			const res = await app.request("/api/databases%2Fcurrent");
 
 			expect([200, 400, 404]).toContain(res.status);
 		});
 
 		it("should reject non-existent sub-routes", async () => {
-			const res = await app.request("/databases/nonexistent");
+			const res = await app.request("/api/databases/nonexistent");
 
 			expect([404, 400]).toContain(res.status);
 		});
 
 		it("should reject deeply nested non-existent routes", async () => {
-			const res = await app.request("/databases/current/extra/path");
+			const res = await app.request("/api/databases/current/extra/path");
 
 			expect([404, 400]).toContain(res.status);
 		});

--- a/packages/server/tests/routes/mongodb/databases.routes.mongodb.test.ts
+++ b/packages/server/tests/routes/mongodb/databases.routes.mongodb.test.ts
@@ -70,7 +70,7 @@ describe("Databases Routes (MongoDB)", () => {
 			];
 			mockDao.getDatabasesList.mockResolvedValue(mockDatabases);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -82,7 +82,7 @@ describe("Databases Routes (MongoDB)", () => {
 		it("returns empty array when no databases exist", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -95,7 +95,7 @@ describe("Databases Routes (MongoDB)", () => {
 				{ name: "onlydb", size: "1.0 KB", owner: "n/a", encoding: "n/a" },
 			]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -112,7 +112,7 @@ describe("Databases Routes (MongoDB)", () => {
 			}));
 			mockDao.getDatabasesList.mockResolvedValue(mockDatabases);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -124,7 +124,7 @@ describe("Databases Routes (MongoDB)", () => {
 				new HTTPException(500, { message: "No databases returned from MongoDB" }),
 			);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(500);
 		});
@@ -134,7 +134,7 @@ describe("Databases Routes (MongoDB)", () => {
 				new Error("connect ECONNREFUSED 127.0.0.1:27017"),
 			);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(503);
 			const json = await res.json();
@@ -144,7 +144,7 @@ describe("Databases Routes (MongoDB)", () => {
 		it("returns 503 on MongoDB connection timeout", async () => {
 			mockDao.getDatabasesList.mockRejectedValue(new Error("timeout expired"));
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(503);
 		});
@@ -152,7 +152,7 @@ describe("Databases Routes (MongoDB)", () => {
 		it("returns 500 on generic error", async () => {
 			mockDao.getDatabasesList.mockRejectedValue(new Error("Unexpected MongoDB error"));
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(500);
 			const json = await res.json();
@@ -164,7 +164,7 @@ describe("Databases Routes (MongoDB)", () => {
 		it("returns current MongoDB database with 200 status", async () => {
 			mockDao.getCurrentDatabase.mockResolvedValue({ db: "myapp" });
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -176,7 +176,7 @@ describe("Databases Routes (MongoDB)", () => {
 		it("handles db name with underscores and hyphens", async () => {
 			mockDao.getCurrentDatabase.mockResolvedValue({ db: "my-production_db" });
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -188,7 +188,7 @@ describe("Databases Routes (MongoDB)", () => {
 				new HTTPException(500, { message: "Failed to get current db" }),
 			);
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(500);
 		});
@@ -196,7 +196,7 @@ describe("Databases Routes (MongoDB)", () => {
 		it("returns 503 on connection error", async () => {
 			mockDao.getCurrentDatabase.mockRejectedValue(new Error("connection refused"));
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(503);
 		});
@@ -215,7 +215,7 @@ describe("Databases Routes (MongoDB)", () => {
 			};
 			mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockInfo);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -235,7 +235,7 @@ describe("Databases Routes (MongoDB)", () => {
 			};
 			mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockInfo);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -255,7 +255,7 @@ describe("Databases Routes (MongoDB)", () => {
 			};
 			mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockInfo);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -267,7 +267,7 @@ describe("Databases Routes (MongoDB)", () => {
 				new HTTPException(500, { message: "Failed to get connection info" }),
 			);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(500);
 		});
@@ -275,7 +275,7 @@ describe("Databases Routes (MongoDB)", () => {
 		it("returns 503 on connection timeout", async () => {
 			mockDao.getDatabaseConnectionInfo.mockRejectedValue(new Error("timeout expired"));
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(503);
 		});
@@ -285,7 +285,7 @@ describe("Databases Routes (MongoDB)", () => {
 		it("includes CORS headers", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
 		});
@@ -293,7 +293,7 @@ describe("Databases Routes (MongoDB)", () => {
 		it("returns JSON content type", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.headers.get("Content-Type")).toContain("application/json");
 		});

--- a/packages/server/tests/routes/mongodb/query.routes.mongodb.test.ts
+++ b/packages/server/tests/routes/mongodb/query.routes.mongodb.test.ts
@@ -81,7 +81,7 @@ describe("Query Routes (MongoDB)", () => {
 				limit: 50,
 			});
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query }),
@@ -113,7 +113,7 @@ describe("Query Routes (MongoDB)", () => {
 				],
 			});
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query }),
@@ -139,7 +139,7 @@ describe("Query Routes (MongoDB)", () => {
 				document: { name: "Charlie", email: "charlie@example.com" },
 			});
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query }),
@@ -170,7 +170,7 @@ describe("Query Routes (MongoDB)", () => {
 				],
 			});
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query }),
@@ -197,7 +197,7 @@ describe("Query Routes (MongoDB)", () => {
 				update: { $set: { age: 31 } },
 			});
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query }),
@@ -224,7 +224,7 @@ describe("Query Routes (MongoDB)", () => {
 				update: { $set: { status: "inactive" } },
 			});
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query }),
@@ -250,7 +250,7 @@ describe("Query Routes (MongoDB)", () => {
 				filter: { _id: "507f1f77bcf86cd799439011" },
 			});
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query }),
@@ -274,7 +274,7 @@ describe("Query Routes (MongoDB)", () => {
 				filter: { expiresAt: { $lt: "2025-01-01" } },
 			});
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query }),
@@ -300,7 +300,7 @@ describe("Query Routes (MongoDB)", () => {
 				filter: { active: true },
 			});
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query }),
@@ -316,7 +316,7 @@ describe("Query Routes (MongoDB)", () => {
 				new HTTPException(400, { message: "Query is required" }),
 			);
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "" }),
@@ -330,7 +330,7 @@ describe("Query Routes (MongoDB)", () => {
 				new HTTPException(400, { message: "Mongo query must be valid JSON" }),
 			);
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "not json" }),
@@ -346,7 +346,7 @@ describe("Query Routes (MongoDB)", () => {
 				}),
 			);
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: JSON.stringify({ collection: "users" }) }),
@@ -360,7 +360,7 @@ describe("Query Routes (MongoDB)", () => {
 				new HTTPException(400, { message: "Unsupported Mongo operation" }),
 			);
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -372,7 +372,7 @@ describe("Query Routes (MongoDB)", () => {
 		});
 
 		it("returns 400 when request body is missing query field", async () => {
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({}),
@@ -382,7 +382,7 @@ describe("Query Routes (MongoDB)", () => {
 		});
 
 		it("returns 400 when db param is missing", async () => {
-			const res = await app.request("/mongodb/query", {
+			const res = await app.request("/api/mongodb/query", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -398,7 +398,7 @@ describe("Query Routes (MongoDB)", () => {
 				new Error("connect ECONNREFUSED 127.0.0.1:27017"),
 			);
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -412,7 +412,7 @@ describe("Query Routes (MongoDB)", () => {
 		it("returns 503 on connection timeout", async () => {
 			mockDao.executeQuery.mockRejectedValue(new Error("timeout expired"));
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -431,7 +431,7 @@ describe("Query Routes (MongoDB)", () => {
 				duration: 12.7,
 			});
 
-			const res = await app.request("/mongodb/query?db=testdb", {
+			const res = await app.request("/api/mongodb/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({

--- a/packages/server/tests/routes/mongodb/records.routes.mongodb.test.ts
+++ b/packages/server/tests/routes/mongodb/records.routes.mongodb.test.ts
@@ -70,7 +70,7 @@ describe("Records Routes (MongoDB)", () => {
 				data: { name: "Alice", email: "alice@example.com", age: 30 },
 			};
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -97,7 +97,7 @@ describe("Records Routes (MongoDB)", () => {
 				},
 			};
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -114,7 +114,7 @@ describe("Records Routes (MongoDB)", () => {
 				data: { _id: "507f1f77bcf86cd799439011", key: "theme", value: "dark" },
 			};
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -124,7 +124,7 @@ describe("Records Routes (MongoDB)", () => {
 		});
 
 		it("returns 400 when tableName is missing", async () => {
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ data: { name: "Alice" } }),
@@ -134,7 +134,7 @@ describe("Records Routes (MongoDB)", () => {
 		});
 
 		it("returns 400 when db param is missing", async () => {
-			const res = await app.request("/mongodb/records", {
+			const res = await app.request("/api/mongodb/records", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", data: {} }),
@@ -148,7 +148,7 @@ describe("Records Routes (MongoDB)", () => {
 				new HTTPException(500, { message: 'Failed to insert record into "users"' }),
 			);
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", data: { name: "Bob" } }),
@@ -162,7 +162,7 @@ describe("Records Routes (MongoDB)", () => {
 				new Error("connect ECONNREFUSED 127.0.0.1:27017"),
 			);
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", data: { name: "Bob" } }),
@@ -193,7 +193,7 @@ describe("Records Routes (MongoDB)", () => {
 				],
 			};
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -215,7 +215,7 @@ describe("Records Routes (MongoDB)", () => {
 		it("returns 0 updated records for no-op update", async () => {
 			mockDao.updateRecords.mockResolvedValue({ updatedCount: 0 });
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -243,7 +243,7 @@ describe("Records Routes (MongoDB)", () => {
 				}),
 			);
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -267,7 +267,7 @@ describe("Records Routes (MongoDB)", () => {
 				new HTTPException(400, { message: 'Primary key "_id" not found in row data.' }),
 			);
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -297,7 +297,7 @@ describe("Records Routes (MongoDB)", () => {
 				],
 			};
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -316,7 +316,7 @@ describe("Records Routes (MongoDB)", () => {
 				relatedRecords: [],
 			});
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -337,7 +337,7 @@ describe("Records Routes (MongoDB)", () => {
 				relatedRecords: [],
 			});
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -352,7 +352,7 @@ describe("Records Routes (MongoDB)", () => {
 		});
 
 		it("returns 400 when body is invalid", async () => {
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users" }),
@@ -364,7 +364,7 @@ describe("Records Routes (MongoDB)", () => {
 		it("returns 503 on connection failure", async () => {
 			mockDao.deleteRecords.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mongodb/records?db=testdb", {
+			const res = await app.request("/api/mongodb/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -390,7 +390,7 @@ describe("Records Routes (MongoDB)", () => {
 				],
 			};
 
-			const res = await app.request("/mongodb/records/force?db=testdb", {
+			const res = await app.request("/api/mongodb/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -404,7 +404,7 @@ describe("Records Routes (MongoDB)", () => {
 		it("returns 503 on connection failure", async () => {
 			mockDao.forceDeleteRecords.mockRejectedValue(new Error("connection refused"));
 
-			const res = await app.request("/mongodb/records/force?db=testdb", {
+			const res = await app.request("/api/mongodb/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -435,7 +435,7 @@ describe("Records Routes (MongoDB)", () => {
 				],
 			};
 
-			const res = await app.request("/mongodb/records/bulk?db=testdb", {
+			const res = await app.request("/api/mongodb/records/bulk?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -455,7 +455,7 @@ describe("Records Routes (MongoDB)", () => {
 				failureCount: 1,
 			});
 
-			const res = await app.request("/mongodb/records/bulk?db=testdb", {
+			const res = await app.request("/api/mongodb/records/bulk?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -474,7 +474,7 @@ describe("Records Routes (MongoDB)", () => {
 				new HTTPException(400, { message: "At least one record is required" }),
 			);
 
-			const res = await app.request("/mongodb/records/bulk?db=testdb", {
+			const res = await app.request("/api/mongodb/records/bulk?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", records: [] }),
@@ -488,7 +488,7 @@ describe("Records Routes (MongoDB)", () => {
 				new HTTPException(500, { message: "Bulk insert failed: duplicate key error" }),
 			);
 
-			const res = await app.request("/mongodb/records/bulk?db=testdb", {
+			const res = await app.request("/api/mongodb/records/bulk?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -501,7 +501,7 @@ describe("Records Routes (MongoDB)", () => {
 		});
 
 		it("returns 400 when tableName is missing", async () => {
-			const res = await app.request("/mongodb/records/bulk?db=testdb", {
+			const res = await app.request("/api/mongodb/records/bulk?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ records: [{ name: "Alice" }] }),

--- a/packages/server/tests/routes/mongodb/tables.routes.mongodb.test.ts
+++ b/packages/server/tests/routes/mongodb/tables.routes.mongodb.test.ts
@@ -71,7 +71,7 @@ describe("Tables Routes (MongoDB)", () => {
 			];
 			mockDao.getTablesList.mockResolvedValue(mockTables);
 
-			const res = await app.request("/mongodb/tables?db=testdb");
+			const res = await app.request("/api/mongodb/tables?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -82,7 +82,7 @@ describe("Tables Routes (MongoDB)", () => {
 		it("returns empty array when no collections exist", async () => {
 			mockDao.getTablesList.mockResolvedValue([]);
 
-			const res = await app.request("/mongodb/tables?db=emptydb");
+			const res = await app.request("/api/mongodb/tables?db=emptydb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -90,7 +90,7 @@ describe("Tables Routes (MongoDB)", () => {
 		});
 
 		it("returns 400 when db param is missing", async () => {
-			const res = await app.request("/mongodb/tables");
+			const res = await app.request("/api/mongodb/tables");
 
 			expect(res.status).toBe(400);
 		});
@@ -100,7 +100,7 @@ describe("Tables Routes (MongoDB)", () => {
 				new HTTPException(500, { message: "MongoDB error" }),
 			);
 
-			const res = await app.request("/mongodb/tables?db=testdb");
+			const res = await app.request("/api/mongodb/tables?db=testdb");
 
 			expect(res.status).toBe(500);
 		});
@@ -110,7 +110,7 @@ describe("Tables Routes (MongoDB)", () => {
 				new Error("connect ECONNREFUSED 127.0.0.1:27017"),
 			);
 
-			const res = await app.request("/mongodb/tables?db=testdb");
+			const res = await app.request("/api/mongodb/tables?db=testdb");
 
 			expect(res.status).toBe(503);
 		});
@@ -120,7 +120,7 @@ describe("Tables Routes (MongoDB)", () => {
 		it("creates a collection with a field definition and returns 200", async () => {
 			mockDao.createTable.mockResolvedValue(undefined);
 
-			const res = await app.request("/mongodb/tables?db=testdb", {
+			const res = await app.request("/api/mongodb/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -139,7 +139,7 @@ describe("Tables Routes (MongoDB)", () => {
 		it("creates a collection with fields and JSON Schema validator", async () => {
 			mockDao.createTable.mockResolvedValue(undefined);
 
-			const res = await app.request("/mongodb/tables?db=testdb", {
+			const res = await app.request("/api/mongodb/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -155,7 +155,7 @@ describe("Tables Routes (MongoDB)", () => {
 		});
 
 		it("returns 400 when tableName is missing", async () => {
-			const res = await app.request("/mongodb/tables?db=testdb", {
+			const res = await app.request("/api/mongodb/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -173,7 +173,7 @@ describe("Tables Routes (MongoDB)", () => {
 				new HTTPException(400, { message: 'Collection "users" already exists' }),
 			);
 
-			const res = await app.request("/mongodb/tables?db=testdb", {
+			const res = await app.request("/api/mongodb/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", fields: [] }),
@@ -191,7 +191,7 @@ describe("Tables Routes (MongoDB)", () => {
 				relatedRecords: [],
 			});
 
-			const res = await app.request("/mongodb/tables/users?db=testdb", {
+			const res = await app.request("/api/mongodb/tables/users?db=testdb", {
 				method: "DELETE",
 			});
 
@@ -199,7 +199,7 @@ describe("Tables Routes (MongoDB)", () => {
 		});
 
 		it("returns 400 when db param is missing", async () => {
-			const res = await app.request("/mongodb/tables/users", {
+			const res = await app.request("/api/mongodb/tables/users", {
 				method: "DELETE",
 			});
 
@@ -249,7 +249,7 @@ describe("Tables Routes (MongoDB)", () => {
 			];
 			mockDao.getTableColumns.mockResolvedValue(mockColumns);
 
-			const res = await app.request("/mongodb/tables/users/columns?db=testdb");
+			const res = await app.request("/api/mongodb/tables/users/columns?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -263,7 +263,7 @@ describe("Tables Routes (MongoDB)", () => {
 		it("returns empty columns for empty collection", async () => {
 			mockDao.getTableColumns.mockResolvedValue([]);
 
-			const res = await app.request("/mongodb/tables/empty_coll/columns?db=testdb");
+			const res = await app.request("/api/mongodb/tables/empty_coll/columns?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -273,7 +273,7 @@ describe("Tables Routes (MongoDB)", () => {
 		it("returns 503 on connection failure", async () => {
 			mockDao.getTableColumns.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mongodb/tables/users/columns?db=testdb");
+			const res = await app.request("/api/mongodb/tables/users/columns?db=testdb");
 
 			expect(res.status).toBe(503);
 		});
@@ -297,7 +297,7 @@ describe("Tables Routes (MongoDB)", () => {
 			};
 			mockDao.getTableData.mockResolvedValue(mockData);
 
-			const res = await app.request("/mongodb/tables/users/data?db=testdb&limit=50");
+			const res = await app.request("/api/mongodb/tables/users/data?db=testdb&limit=50");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -322,7 +322,7 @@ describe("Tables Routes (MongoDB)", () => {
 			mockDao.getTableData.mockResolvedValue(mockData);
 
 			const res = await app.request(
-				"/mongodb/tables/orders/data?db=testdb&limit=10&cursor=eyJvZmZzZXQiOjEwfQ",
+				"/api/mongodb/tables/orders/data?db=testdb&limit=10&cursor=eyJvZmZzZXQiOjEwfQ",
 			);
 
 			expect(res.status).toBe(200);
@@ -334,7 +334,7 @@ describe("Tables Routes (MongoDB)", () => {
 		it("returns 503 on connection failure", async () => {
 			mockDao.getTableData.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mongodb/tables/users/data?db=testdb");
+			const res = await app.request("/api/mongodb/tables/users/data?db=testdb");
 
 			expect(res.status).toBe(503);
 		});
@@ -363,7 +363,7 @@ describe("Tables Routes (MongoDB)", () => {
 			);
 			mockDao.getTableSchema.mockResolvedValue(mockSchema);
 
-			const res = await app.request("/mongodb/tables/users/schema?db=testdb");
+			const res = await app.request("/api/mongodb/tables/users/schema?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -375,7 +375,7 @@ describe("Tables Routes (MongoDB)", () => {
 				new HTTPException(404, { message: 'Collection "ghost" does not exist' }),
 			);
 
-			const res = await app.request("/mongodb/tables/ghost/schema?db=testdb");
+			const res = await app.request("/api/mongodb/tables/ghost/schema?db=testdb");
 
 			expect(res.status).toBe(404);
 		});
@@ -388,7 +388,7 @@ describe("Tables Routes (MongoDB)", () => {
 				rows: [{ _id: "1", name: "Alice", email: "alice@example.com" }],
 			});
 
-			const res = await app.request("/mongodb/tables/users/export?db=testdb&format=csv");
+			const res = await app.request("/api/mongodb/tables/users/export?db=testdb&format=csv");
 
 			expect(res.status).toBe(200);
 			expect(res.headers.get("Content-Type")).toContain("text/csv");
@@ -401,7 +401,7 @@ describe("Tables Routes (MongoDB)", () => {
 				rows: [{ _id: "1", name: "Alice" }],
 			});
 
-			const res = await app.request("/mongodb/tables/users/export?db=testdb&format=json");
+			const res = await app.request("/api/mongodb/tables/users/export?db=testdb&format=json");
 
 			expect(res.status).toBe(200);
 			expect(res.headers.get("Content-Type")).toContain("application/json");
@@ -412,7 +412,7 @@ describe("Tables Routes (MongoDB)", () => {
 		it("deletes a field from all documents and returns 200", async () => {
 			mockDao.deleteColumn.mockResolvedValue({ deletedCount: 42 });
 
-			const res = await app.request("/mongodb/tables/users/columns/age?db=testdb", {
+			const res = await app.request("/api/mongodb/tables/users/columns/age?db=testdb", {
 				method: "DELETE",
 			});
 
@@ -429,7 +429,7 @@ describe("Tables Routes (MongoDB)", () => {
 		});
 
 		it("returns 400 when db param is missing", async () => {
-			const res = await app.request("/mongodb/tables/users/columns/age", {
+			const res = await app.request("/api/mongodb/tables/users/columns/age", {
 				method: "DELETE",
 			});
 
@@ -439,7 +439,7 @@ describe("Tables Routes (MongoDB)", () => {
 		it("returns 503 on connection failure", async () => {
 			mockDao.deleteColumn.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mongodb/tables/users/columns/age?db=testdb", {
+			const res = await app.request("/api/mongodb/tables/users/columns/age?db=testdb", {
 				method: "DELETE",
 			});
 
@@ -451,7 +451,7 @@ describe("Tables Routes (MongoDB)", () => {
 		it("adds a field to all documents and returns 200", async () => {
 			mockDao.addColumn.mockResolvedValue(undefined);
 
-			const res = await app.request("/mongodb/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/mongodb/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -477,7 +477,7 @@ describe("Tables Routes (MongoDB)", () => {
 				}),
 			);
 
-			const res = await app.request("/mongodb/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/mongodb/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -495,7 +495,7 @@ describe("Tables Routes (MongoDB)", () => {
 				new HTTPException(404, { message: 'Collection "ghost" does not exist' }),
 			);
 
-			const res = await app.request("/mongodb/tables/ghost/columns?db=testdb", {
+			const res = await app.request("/api/mongodb/tables/ghost/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -514,7 +514,7 @@ describe("Tables Routes (MongoDB)", () => {
 			mockDao.renameColumn.mockResolvedValue(undefined);
 
 			const res = await app.request(
-				"/mongodb/tables/users/columns/username/rename?db=testdb",
+				"/api/mongodb/tables/users/columns/username/rename?db=testdb",
 				{
 					method: "PATCH",
 					headers: { "Content-Type": "application/json" },
@@ -541,7 +541,7 @@ describe("Tables Routes (MongoDB)", () => {
 				new HTTPException(400, { message: 'Cannot rename the "_id" field' }),
 			);
 
-			const res = await app.request("/mongodb/tables/users/columns/_id/rename?db=testdb", {
+			const res = await app.request("/api/mongodb/tables/users/columns/_id/rename?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ newColumnName: "id" }),
@@ -558,7 +558,7 @@ describe("Tables Routes (MongoDB)", () => {
 			);
 
 			const res = await app.request(
-				"/mongodb/tables/users/columns/ghost/rename?db=testdb",
+				"/api/mongodb/tables/users/columns/ghost/rename?db=testdb",
 				{
 					method: "PATCH",
 					headers: { "Content-Type": "application/json" },
@@ -577,7 +577,7 @@ describe("Tables Routes (MongoDB)", () => {
 			);
 
 			const res = await app.request(
-				"/mongodb/tables/users/columns/mail/rename?db=testdb",
+				"/api/mongodb/tables/users/columns/mail/rename?db=testdb",
 				{
 					method: "PATCH",
 					headers: { "Content-Type": "application/json" },
@@ -593,7 +593,7 @@ describe("Tables Routes (MongoDB)", () => {
 		it("updates the field validator and returns 200", async () => {
 			mockDao.alterColumn.mockResolvedValue(undefined);
 
-			const res = await app.request("/mongodb/tables/users/columns/age?db=testdb", {
+			const res = await app.request("/api/mongodb/tables/users/columns/age?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ columnType: "int", isNullable: false }),
@@ -618,7 +618,7 @@ describe("Tables Routes (MongoDB)", () => {
 				new HTTPException(400, { message: 'Cannot alter the "_id" field' }),
 			);
 
-			const res = await app.request("/mongodb/tables/users/columns/_id?db=testdb", {
+			const res = await app.request("/api/mongodb/tables/users/columns/_id?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ columnType: "string", isNullable: true }),
@@ -632,7 +632,7 @@ describe("Tables Routes (MongoDB)", () => {
 				new HTTPException(404, { message: 'Collection "ghost" does not exist' }),
 			);
 
-			const res = await app.request("/mongodb/tables/ghost/columns/field?db=testdb", {
+			const res = await app.request("/api/mongodb/tables/ghost/columns/field?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ columnType: "string", isNullable: true }),

--- a/packages/server/tests/routes/mssql/databases.routes.mssql.test.ts
+++ b/packages/server/tests/routes/mssql/databases.routes.mssql.test.ts
@@ -65,7 +65,7 @@ describe("Databases Routes (MSSQL)", () => {
 				{ name: "appdb", size: "256 MB" },
 			]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 			const json = await res.json();
 
 			expect(res.status).toBe(200);
@@ -79,7 +79,7 @@ describe("Databases Routes (MSSQL)", () => {
 				new Error("connect ECONNREFUSED 127.0.0.1:1433"),
 			);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 			expect(res.status).toBe(503);
 		});
 
@@ -88,7 +88,7 @@ describe("Databases Routes (MSSQL)", () => {
 				new Error("Unexpected SQL Server error"),
 			);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 			expect(res.status).toBe(500);
 		});
 	});
@@ -97,7 +97,7 @@ describe("Databases Routes (MSSQL)", () => {
 		it("returns current database and dbType", async () => {
 			mockDao.getCurrentDatabase.mockResolvedValue({ db: "appdb" });
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 			const json = await res.json();
 
 			expect(res.status).toBe(200);
@@ -109,7 +109,7 @@ describe("Databases Routes (MSSQL)", () => {
 				new HTTPException(500, { message: "No current database returned" }),
 			);
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 			expect(res.status).toBe(500);
 		});
 	});
@@ -126,7 +126,7 @@ describe("Databases Routes (MSSQL)", () => {
 				max_connections: 32767,
 			});
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 			const json = await res.json();
 
 			expect(res.status).toBe(200);
@@ -137,7 +137,7 @@ describe("Databases Routes (MSSQL)", () => {
 		it("returns 503 on connection timeout", async () => {
 			mockDao.getDatabaseConnectionInfo.mockRejectedValue(new Error("timeout expired"));
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 			expect(res.status).toBe(503);
 		});
 	});
@@ -145,7 +145,7 @@ describe("Databases Routes (MSSQL)", () => {
 	describe("Response headers", () => {
 		it("includes CORS and JSON headers", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
 			expect(res.headers.get("Content-Type")).toContain("application/json");

--- a/packages/server/tests/routes/mssql/query.routes.mssql.test.ts
+++ b/packages/server/tests/routes/mssql/query.routes.mssql.test.ts
@@ -67,7 +67,7 @@ describe("Query Routes (MSSQL)", () => {
 				duration: 7.4,
 			});
 
-			const res = await app.request("/mssql/query?db=testdb", {
+			const res = await app.request("/api/mssql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT TOP 1 id, name FROM users" }),
@@ -90,7 +90,7 @@ describe("Query Routes (MSSQL)", () => {
 				duration: 4.2,
 			});
 
-			const res = await app.request("/mssql/query?db=testdb", {
+			const res = await app.request("/api/mssql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT TOP 1 [id] FROM [dbo].[users]" }),
@@ -100,7 +100,7 @@ describe("Query Routes (MSSQL)", () => {
 		});
 
 		it("returns 400 when query payload is missing", async () => {
-			const res = await app.request("/mssql/query?db=testdb", {
+			const res = await app.request("/api/mssql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({}),
@@ -110,7 +110,7 @@ describe("Query Routes (MSSQL)", () => {
 		});
 
 		it("returns 400 when db query param is missing", async () => {
-			const res = await app.request("/mssql/query", {
+			const res = await app.request("/api/mssql/query", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -124,7 +124,7 @@ describe("Query Routes (MSSQL)", () => {
 				new Error("connect ECONNREFUSED 127.0.0.1:1433"),
 			);
 
-			const res = await app.request("/mssql/query?db=testdb", {
+			const res = await app.request("/api/mssql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -138,7 +138,7 @@ describe("Query Routes (MSSQL)", () => {
 				new Error("Incorrect syntax near 'SELEC'"),
 			);
 
-			const res = await app.request("/mssql/query?db=testdb", {
+			const res = await app.request("/api/mssql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELEC * FROM users" }),
@@ -152,7 +152,7 @@ describe("Query Routes (MSSQL)", () => {
 				new HTTPException(500, { message: "Execution failed" }),
 			);
 
-			const res = await app.request("/mssql/query?db=testdb", {
+			const res = await app.request("/api/mssql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -164,7 +164,7 @@ describe("Query Routes (MSSQL)", () => {
 
 	describe("Other behavior", () => {
 		it("rejects invalid database type", async () => {
-			const res = await app.request("/sqlite/query?db=testdb", {
+			const res = await app.request("/api/sqlite/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -174,7 +174,7 @@ describe("Query Routes (MSSQL)", () => {
 		});
 
 		it("returns 404 for unsupported methods", async () => {
-			const res = await app.request("/mssql/query?db=testdb", { method: "GET" });
+			const res = await app.request("/api/mssql/query?db=testdb", { method: "GET" });
 			expect(res.status).toBe(404);
 		});
 
@@ -188,7 +188,7 @@ describe("Query Routes (MSSQL)", () => {
 
 			const responses = await Promise.all(
 				Array.from({ length: 8 }, () =>
-					app.request("/mssql/query?db=testdb", {
+					app.request("/api/mssql/query?db=testdb", {
 						method: "POST",
 						headers: { "Content-Type": "application/json" },
 						body: JSON.stringify({ query: "SELECT 1 as value" }),

--- a/packages/server/tests/routes/mssql/records.routes.mssql.test.ts
+++ b/packages/server/tests/routes/mssql/records.routes.mssql.test.ts
@@ -62,7 +62,7 @@ describe("Records Routes (MSSQL)", () => {
 		it("adds a record and returns success message", async () => {
 			mockDao.addRecord.mockResolvedValue({ insertedCount: 1 });
 
-			const res = await app.request("/mssql/records?db=testdb", {
+			const res = await app.request("/api/mssql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -77,7 +77,7 @@ describe("Records Routes (MSSQL)", () => {
 		});
 
 		it("returns 400 for invalid payload", async () => {
-			const res = await app.request("/mssql/records?db=testdb", {
+			const res = await app.request("/api/mssql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ data: { name: "Ali" } }),
@@ -91,7 +91,7 @@ describe("Records Routes (MSSQL)", () => {
 				new Error("connect ECONNREFUSED 127.0.0.1:1433"),
 			);
 
-			const res = await app.request("/mssql/records?db=testdb", {
+			const res = await app.request("/api/mssql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", data: { name: "Ali" } }),
@@ -105,7 +105,7 @@ describe("Records Routes (MSSQL)", () => {
 		it("updates records with default primary key", async () => {
 			mockDao.updateRecords.mockResolvedValue({ updatedCount: 2 });
 
-			const res = await app.request("/mssql/records?db=testdb", {
+			const res = await app.request("/api/mssql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -126,7 +126,7 @@ describe("Records Routes (MSSQL)", () => {
 				new HTTPException(404, { message: "Record not found" }),
 			);
 
-			const res = await app.request("/mssql/records?db=testdb", {
+			const res = await app.request("/api/mssql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -148,7 +148,7 @@ describe("Records Routes (MSSQL)", () => {
 				relatedRecords: [],
 			});
 
-			const res = await app.request("/mssql/records?db=testdb", {
+			const res = await app.request("/api/mssql/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -176,7 +176,7 @@ describe("Records Routes (MSSQL)", () => {
 				],
 			});
 
-			const res = await app.request("/mssql/records?db=testdb", {
+			const res = await app.request("/api/mssql/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -193,7 +193,7 @@ describe("Records Routes (MSSQL)", () => {
 		it("force deletes records", async () => {
 			mockDao.forceDeleteRecords.mockResolvedValue({ deletedCount: 4 });
 
-			const res = await app.request("/mssql/records/force?db=testdb", {
+			const res = await app.request("/api/mssql/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -217,7 +217,7 @@ describe("Records Routes (MSSQL)", () => {
 				failureCount: 0,
 			});
 
-			const res = await app.request("/mssql/records/bulk?db=testdb", {
+			const res = await app.request("/api/mssql/records/bulk?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -235,7 +235,7 @@ describe("Records Routes (MSSQL)", () => {
 
 	describe("Validation and behavior", () => {
 		it("rejects invalid database type", async () => {
-			const res = await app.request("/invalid/records?db=testdb", {
+			const res = await app.request("/api/invalid/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", data: { name: "X" } }),
@@ -244,7 +244,7 @@ describe("Records Routes (MSSQL)", () => {
 		});
 
 		it("returns 404 for unsupported methods", async () => {
-			const res = await app.request("/mssql/records?db=testdb", { method: "GET" });
+			const res = await app.request("/api/mssql/records?db=testdb", { method: "GET" });
 			expect(res.status).toBe(404);
 		});
 
@@ -253,7 +253,7 @@ describe("Records Routes (MSSQL)", () => {
 
 			const responses = await Promise.all(
 				Array.from({ length: 6 }, (_, i) =>
-					app.request("/mssql/records?db=testdb", {
+					app.request("/api/mssql/records?db=testdb", {
 						method: "POST",
 						headers: { "Content-Type": "application/json" },
 						body: JSON.stringify({

--- a/packages/server/tests/routes/mssql/tables.routes.mssql.test.ts
+++ b/packages/server/tests/routes/mssql/tables.routes.mssql.test.ts
@@ -65,7 +65,7 @@ describe("Tables Routes (MSSQL)", () => {
 				{ tableName: "orders", rowCount: 1200 },
 			]);
 
-			const res = await app.request("/mssql/tables?db=testdb");
+			const res = await app.request("/api/mssql/tables?db=testdb");
 			const json = await res.json();
 
 			expect(res.status).toBe(200);
@@ -74,7 +74,7 @@ describe("Tables Routes (MSSQL)", () => {
 		});
 
 		it("returns 400 when db query is missing", async () => {
-			const res = await app.request("/mssql/tables");
+			const res = await app.request("/api/mssql/tables");
 			expect(res.status).toBe(400);
 		});
 	});
@@ -83,7 +83,7 @@ describe("Tables Routes (MSSQL)", () => {
 		it("creates a table", async () => {
 			mockDao.createTable.mockResolvedValue(undefined);
 
-			const res = await app.request("/mssql/tables?db=testdb", {
+			const res = await app.request("/api/mssql/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -105,7 +105,7 @@ describe("Tables Routes (MSSQL)", () => {
 				new Error("connect ECONNREFUSED 127.0.0.1:1433"),
 			);
 
-			const res = await app.request("/mssql/tables?db=testdb", {
+			const res = await app.request("/api/mssql/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -122,7 +122,7 @@ describe("Tables Routes (MSSQL)", () => {
 		it("deletes a column", async () => {
 			mockDao.deleteColumn.mockResolvedValue({ deletedCount: 0 });
 
-			const res = await app.request("/mssql/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/mssql/tables/users/columns/email?db=testdb", {
 				method: "DELETE",
 			});
 			const json = await res.json();
@@ -136,7 +136,7 @@ describe("Tables Routes (MSSQL)", () => {
 				new HTTPException(404, { message: "Table not found" }),
 			);
 
-			const res = await app.request("/mssql/tables/unknown/columns/email?db=testdb", {
+			const res = await app.request("/api/mssql/tables/unknown/columns/email?db=testdb", {
 				method: "DELETE",
 			});
 
@@ -161,7 +161,7 @@ describe("Tables Routes (MSSQL)", () => {
 				},
 			]);
 
-			const res = await app.request("/mssql/tables/users/columns?db=testdb");
+			const res = await app.request("/api/mssql/tables/users/columns?db=testdb");
 			const json = await res.json();
 
 			expect(res.status).toBe(200);
@@ -187,7 +187,7 @@ describe("Tables Routes (MSSQL)", () => {
 				},
 			});
 
-			const res = await app.request("/mssql/tables/users/data?db=testdb");
+			const res = await app.request("/api/mssql/tables/users/data?db=testdb");
 			const json = await res.json();
 
 			expect(res.status).toBe(200);
@@ -219,7 +219,7 @@ describe("Tables Routes (MSSQL)", () => {
 
 			const filters = JSON.stringify([{ columnName: "status", operator: "=", value: "active" }]);
 			const res = await app.request(
-				`/mssql/tables/users/data?db=testdb&limit=25&sort=created_at&order=desc&filters=${encodeURIComponent(filters)}`,
+				`/api/mssql/tables/users/data?db=testdb&limit=25&sort=created_at&order=desc&filters=${encodeURIComponent(filters)}`,
 			);
 
 			expect(res.status).toBe(200);
@@ -236,20 +236,20 @@ describe("Tables Routes (MSSQL)", () => {
 		it("returns 500 on generic DAO error", async () => {
 			mockDao.getTableData.mockRejectedValue(new Error("Unexpected SQL Server error"));
 
-			const res = await app.request("/mssql/tables/users/data?db=testdb");
+			const res = await app.request("/api/mssql/tables/users/data?db=testdb");
 			expect(res.status).toBe(500);
 		});
 	});
 
 	describe("Route behavior", () => {
 		it("rejects unsupported database types", async () => {
-			const res = await app.request("/sqlite/tables?db=testdb");
+			const res = await app.request("/api/sqlite/tables?db=testdb");
 			expect(res.status).toBe(400);
 		});
 
 		it("includes CORS + JSON headers", async () => {
 			mockDao.getTablesList.mockResolvedValue([]);
-			const res = await app.request("/mssql/tables?db=testdb");
+			const res = await app.request("/api/mssql/tables?db=testdb");
 
 			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
 			expect(res.headers.get("Content-Type")).toContain("application/json");
@@ -259,7 +259,7 @@ describe("Tables Routes (MSSQL)", () => {
 			mockDao.getTablesList.mockResolvedValue([{ tableName: "users", rowCount: 10 }]);
 
 			const responses = await Promise.all(
-				Array.from({ length: 6 }, () => app.request("/mssql/tables?db=testdb")),
+				Array.from({ length: 6 }, () => app.request("/api/mssql/tables?db=testdb")),
 			);
 
 			for (const res of responses) {

--- a/packages/server/tests/routes/mysql/databases.routes.mysql.test.ts
+++ b/packages/server/tests/routes/mysql/databases.routes.mysql.test.ts
@@ -70,7 +70,7 @@ describe("Databases Routes (MySQL)", () => {
 
 			mockDao.getDatabasesList.mockResolvedValue(mockDatabases);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -82,7 +82,7 @@ describe("Databases Routes (MySQL)", () => {
 		it("should return empty array when no databases exist", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -95,7 +95,7 @@ describe("Databases Routes (MySQL)", () => {
 
 			mockDao.getDatabasesList.mockResolvedValue(mockDatabases);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -111,7 +111,7 @@ describe("Databases Routes (MySQL)", () => {
 
 			mockDao.getDatabasesList.mockResolvedValue(mockDatabases);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -121,7 +121,7 @@ describe("Databases Routes (MySQL)", () => {
 		it("should include dbType as mysql in response", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -133,7 +133,7 @@ describe("Databases Routes (MySQL)", () => {
 				new HTTPException(500, { message: "Failed to list databases" })
 			);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(500);
 		});
@@ -143,7 +143,7 @@ describe("Databases Routes (MySQL)", () => {
 				new Error("connect ECONNREFUSED 127.0.0.1:3306")
 			);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(503);
 			const json = await res.json();
@@ -155,7 +155,7 @@ describe("Databases Routes (MySQL)", () => {
 				new Error("timeout expired")
 			);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(503);
 		});
@@ -165,7 +165,7 @@ describe("Databases Routes (MySQL)", () => {
 				new Error("Unexpected database error")
 			);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.status).toBe(500);
 			const json = await res.json();
@@ -182,7 +182,7 @@ describe("Databases Routes (MySQL)", () => {
 
 			mockDao.getCurrentDatabase.mockResolvedValue(mockCurrent);
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -196,7 +196,7 @@ describe("Databases Routes (MySQL)", () => {
 
 			mockDao.getCurrentDatabase.mockResolvedValue(mockCurrent);
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -206,7 +206,7 @@ describe("Databases Routes (MySQL)", () => {
 		it("should include dbType as mysql in current response", async () => {
 			mockDao.getCurrentDatabase.mockResolvedValue({ db: "testdb" });
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -218,7 +218,7 @@ describe("Databases Routes (MySQL)", () => {
 				new HTTPException(500, { message: "No current database returned" })
 			);
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(500);
 		});
@@ -228,7 +228,7 @@ describe("Databases Routes (MySQL)", () => {
 				new Error("connection refused")
 			);
 
-			const res = await app.request("/databases/current");
+			const res = await app.request("/api/databases/current");
 
 			expect(res.status).toBe(503);
 		});
@@ -251,7 +251,7 @@ describe("Databases Routes (MySQL)", () => {
 
 			mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockConnectionInfo);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -275,7 +275,7 @@ describe("Databases Routes (MySQL)", () => {
 
 				mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockConnectionInfo);
 
-				const res = await app.request("/databases/connection");
+				const res = await app.request("/api/databases/connection");
 
 				expect(res.status).toBe(200);
 				const json = await res.json();
@@ -296,7 +296,7 @@ describe("Databases Routes (MySQL)", () => {
 
 			mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockConnectionInfo);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -317,7 +317,7 @@ describe("Databases Routes (MySQL)", () => {
 
 			mockDao.getDatabaseConnectionInfo.mockResolvedValue(mockConnectionInfo);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -329,7 +329,7 @@ describe("Databases Routes (MySQL)", () => {
 				new HTTPException(500, { message: "Failed to get connection info" })
 			);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(500);
 		});
@@ -339,7 +339,7 @@ describe("Databases Routes (MySQL)", () => {
 				new Error("connect ECONNREFUSED")
 			);
 
-			const res = await app.request("/databases/connection");
+			const res = await app.request("/api/databases/connection");
 
 			expect(res.status).toBe(503);
 		});
@@ -352,7 +352,7 @@ describe("Databases Routes (MySQL)", () => {
 		it("should include CORS headers", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
 		});
@@ -360,7 +360,7 @@ describe("Databases Routes (MySQL)", () => {
 		it("should return JSON content type", async () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 
-			const res = await app.request("/databases");
+			const res = await app.request("/api/databases");
 
 			expect(res.headers.get("Content-Type")).toContain("application/json");
 		});

--- a/packages/server/tests/routes/mysql/query.routes.mysql.test.ts
+++ b/packages/server/tests/routes/mysql/query.routes.mysql.test.ts
@@ -74,7 +74,7 @@ describe("Query Routes (MySQL)", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT * FROM users" }),
@@ -99,7 +99,7 @@ describe("Query Routes (MySQL)", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -122,7 +122,7 @@ describe("Query Routes (MySQL)", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -145,7 +145,7 @@ describe("Query Routes (MySQL)", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -168,7 +168,7 @@ describe("Query Routes (MySQL)", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -195,7 +195,7 @@ describe("Query Routes (MySQL)", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SHOW TABLES" }),
@@ -219,7 +219,7 @@ describe("Query Routes (MySQL)", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "DESCRIBE users" }),
@@ -240,7 +240,7 @@ describe("Query Routes (MySQL)", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT * FROM users WHERE id = -1" }),
@@ -263,7 +263,7 @@ describe("Query Routes (MySQL)", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT * FROM wide_table LIMIT 1" }),
@@ -284,7 +284,7 @@ describe("Query Routes (MySQL)", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SET @var = 1; SELECT @var as id" }),
@@ -294,7 +294,7 @@ describe("Query Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when query is missing", async () => {
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({}),
@@ -311,7 +311,7 @@ describe("Query Routes (MySQL)", () => {
 				duration: 0.5,
 			});
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "" }),
@@ -322,7 +322,7 @@ describe("Query Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/query", {
+			const res = await app.request("/api/mysql/query", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -332,7 +332,7 @@ describe("Query Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when body is not JSON", async () => {
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: "not-json",
@@ -348,7 +348,7 @@ describe("Query Routes (MySQL)", () => {
 				})
 			);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT * FORM users" }),
@@ -362,7 +362,7 @@ describe("Query Routes (MySQL)", () => {
 				new Error("connect ECONNREFUSED 127.0.0.1:3306")
 			);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -378,7 +378,7 @@ describe("Query Routes (MySQL)", () => {
 				new Error("Unknown table 'users'")
 			);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT * FROM users" }),
@@ -393,7 +393,7 @@ describe("Query Routes (MySQL)", () => {
 	// ============================================
 	describe("Invalid database type validation", () => {
 		it("should return 400 for invalid database type", async () => {
-			const res = await app.request("/invalid/query?db=testdb", {
+			const res = await app.request("/api/invalid/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -403,7 +403,7 @@ describe("Query Routes (MySQL)", () => {
 		});
 
 		it("should return 400 for sqlite database type (not supported)", async () => {
-			const res = await app.request("/sqlite/query?db=testdb", {
+			const res = await app.request("/api/sqlite/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -418,13 +418,13 @@ describe("Query Routes (MySQL)", () => {
 	// ============================================
 	describe("HTTP methods validation", () => {
 		it("should return 404 for GET /mysql/query", async () => {
-			const res = await app.request("/mysql/query?db=testdb");
+			const res = await app.request("/api/mysql/query?db=testdb");
 
 			expect(res.status).toBe(404);
 		});
 
 		it("should return 404 for PUT /mysql/query", async () => {
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "PUT",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({}),
@@ -447,7 +447,7 @@ describe("Query Routes (MySQL)", () => {
 			};
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -464,7 +464,7 @@ describe("Query Routes (MySQL)", () => {
 				duration: 1.0,
 			});
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -487,7 +487,7 @@ describe("Query Routes (MySQL)", () => {
 			});
 
 			const requests = Array.from({ length: 10 }, () =>
-				app.request("/mysql/query?db=testdb", {
+				app.request("/api/mysql/query?db=testdb", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ query: "SELECT 1" }),

--- a/packages/server/tests/routes/mysql/records.routes.mysql.test.ts
+++ b/packages/server/tests/routes/mysql/records.routes.mysql.test.ts
@@ -69,7 +69,7 @@ describe("Records Routes (MySQL)", () => {
 				data: { name: "John Doe", email: "john@example.com" },
 			};
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -101,7 +101,7 @@ describe("Records Routes (MySQL)", () => {
 				},
 			};
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -118,7 +118,7 @@ describe("Records Routes (MySQL)", () => {
 				data: { name: "Jane", email: null, bio: null },
 			};
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -128,7 +128,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when tableName is missing", async () => {
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ data: { name: "Test" } }),
@@ -138,7 +138,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when data is missing", async () => {
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users" }),
@@ -148,7 +148,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/records", {
+			const res = await app.request("/api/mysql/records", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", data: { name: "Test" } }),
@@ -162,7 +162,7 @@ describe("Records Routes (MySQL)", () => {
 				new HTTPException(500, { message: 'Failed to insert record into "users"' }),
 			);
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", data: { name: "Test" } }),
@@ -174,7 +174,7 @@ describe("Records Routes (MySQL)", () => {
 		it("should return 503 when MySQL connection fails", async () => {
 			mockDao.addRecord.mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:3306"));
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", data: { name: "Test" } }),
@@ -199,7 +199,7 @@ describe("Records Routes (MySQL)", () => {
 				updates: [{ rowData: { id: 1, name: "Old Name" }, columnName: "name", value: "New Name" }],
 			};
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -224,7 +224,7 @@ describe("Records Routes (MySQL)", () => {
 				],
 			};
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -244,7 +244,7 @@ describe("Records Routes (MySQL)", () => {
 				updates: [{ rowData: { id: 1 }, columnName: "preferences", value: { theme: "dark" } }],
 			};
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -262,7 +262,7 @@ describe("Records Routes (MySQL)", () => {
 				updates: [{ rowData: { id: 1 }, columnName: "deleted_at", value: null }],
 			};
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -279,7 +279,7 @@ describe("Records Routes (MySQL)", () => {
 				updates: [{ rowData: { id: 1 }, columnName: "name", value: "Updated" }],
 			};
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -293,7 +293,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when tableName is missing", async () => {
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ primaryKey: "id", updates: [{ rowData: { id: 1 }, columnName: "name", value: "Test" }] }),
@@ -303,7 +303,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when updates array is empty", async () => {
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKey: "id", updates: [] }),
@@ -313,7 +313,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/records", {
+			const res = await app.request("/api/mysql/records", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKey: "id", updates: [{ rowData: { id: 1 }, columnName: "name", value: "Test" }] }),
@@ -327,7 +327,7 @@ describe("Records Routes (MySQL)", () => {
 				new HTTPException(404, { message: 'Record with id = 999 not found in table "users"' }),
 			);
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKey: "id", updates: [{ rowData: { id: 999 }, columnName: "name", value: "Test" }] }),
@@ -339,7 +339,7 @@ describe("Records Routes (MySQL)", () => {
 		it("should return 503 when MySQL connection fails", async () => {
 			mockDao.updateRecords.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKey: "id", updates: [{ rowData: { id: 1 }, columnName: "name", value: "Test" }] }),
@@ -358,7 +358,7 @@ describe("Records Routes (MySQL)", () => {
 
 			const body = { tableName: "users", primaryKeys: [{ columnName: "id", value: 1 }] };
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -382,7 +382,7 @@ describe("Records Routes (MySQL)", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }, { columnName: "id", value: 2 }, { columnName: "id", value: 3 }],
 			};
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -409,7 +409,7 @@ describe("Records Routes (MySQL)", () => {
 
 			const body = { tableName: "users", primaryKeys: [{ columnName: "id", value: 1 }] };
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -423,7 +423,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when tableName is missing", async () => {
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ primaryKeys: [{ columnName: "id", value: 1 }] }),
@@ -433,7 +433,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when primaryKeys is empty", async () => {
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKeys: [] }),
@@ -443,7 +443,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/records", {
+			const res = await app.request("/api/mysql/records", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKeys: [{ columnName: "id", value: 1 }] }),
@@ -457,7 +457,7 @@ describe("Records Routes (MySQL)", () => {
 				new HTTPException(500, { message: 'Failed to delete records from "users"' }),
 			);
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKeys: [{ columnName: "id", value: 1 }] }),
@@ -469,7 +469,7 @@ describe("Records Routes (MySQL)", () => {
 		it("should return 503 when MySQL connection fails", async () => {
 			mockDao.deleteRecords.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKeys: [{ columnName: "id", value: 1 }] }),
@@ -488,7 +488,7 @@ describe("Records Routes (MySQL)", () => {
 
 			const body = { tableName: "users", primaryKeys: [{ columnName: "id", value: 1 }] };
 
-			const res = await app.request("/mysql/records/force?db=testdb", {
+			const res = await app.request("/api/mysql/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -512,7 +512,7 @@ describe("Records Routes (MySQL)", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }, { columnName: "id", value: 2 }],
 			};
 
-			const res = await app.request("/mysql/records/force?db=testdb", {
+			const res = await app.request("/api/mysql/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -524,7 +524,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when tableName is missing", async () => {
-			const res = await app.request("/mysql/records/force?db=testdb", {
+			const res = await app.request("/api/mysql/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ primaryKeys: [{ columnName: "id", value: 1 }] }),
@@ -534,7 +534,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when primaryKeys is empty", async () => {
-			const res = await app.request("/mysql/records/force?db=testdb", {
+			const res = await app.request("/api/mysql/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKeys: [] }),
@@ -544,7 +544,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/records/force", {
+			const res = await app.request("/api/mysql/records/force", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKeys: [{ columnName: "id", value: 1 }] }),
@@ -558,7 +558,7 @@ describe("Records Routes (MySQL)", () => {
 				new HTTPException(500, { message: 'Failed to force delete records from "users"' }),
 			);
 
-			const res = await app.request("/mysql/records/force?db=testdb", {
+			const res = await app.request("/api/mysql/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKeys: [{ columnName: "id", value: 1 }] }),
@@ -570,7 +570,7 @@ describe("Records Routes (MySQL)", () => {
 		it("should return 503 when MySQL connection fails", async () => {
 			mockDao.forceDeleteRecords.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mysql/records/force?db=testdb", {
+			const res = await app.request("/api/mysql/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKeys: [{ columnName: "id", value: 1 }] }),
@@ -601,7 +601,7 @@ describe("Records Routes (MySQL)", () => {
 				],
 			};
 
-			const res = await app.request("/mysql/records/bulk?db=testdb", {
+			const res = await app.request("/api/mysql/records/bulk?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -614,7 +614,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when tableName is missing", async () => {
-			const res = await app.request("/mysql/records/bulk?db=testdb", {
+			const res = await app.request("/api/mysql/records/bulk?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ records: [{ name: "Alice" }] }),
@@ -624,7 +624,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when records array is empty", async () => {
-			const res = await app.request("/mysql/records/bulk?db=testdb", {
+			const res = await app.request("/api/mysql/records/bulk?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", records: [] }),
@@ -636,7 +636,7 @@ describe("Records Routes (MySQL)", () => {
 		it("should return 503 when MySQL connection fails", async () => {
 			mockDao.bulkInsertRecords.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mysql/records/bulk?db=testdb", {
+			const res = await app.request("/api/mysql/records/bulk?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", records: [{ name: "Alice" }] }),
@@ -651,7 +651,7 @@ describe("Records Routes (MySQL)", () => {
 	// ============================================
 	describe("Invalid database type validation", () => {
 		it("should return 400 for invalid database type on POST", async () => {
-			const res = await app.request("/invalid/records?db=testdb", {
+			const res = await app.request("/api/invalid/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", data: { name: "Test" } }),
@@ -661,7 +661,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 400 for sqlite database type on DELETE", async () => {
-			const res = await app.request("/sqlite/records?db=testdb", {
+			const res = await app.request("/api/sqlite/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", primaryKeys: [{ columnName: "id", value: 1 }] }),
@@ -676,12 +676,12 @@ describe("Records Routes (MySQL)", () => {
 	// ============================================
 	describe("HTTP methods validation", () => {
 		it("should return 404 for GET /mysql/records", async () => {
-			const res = await app.request("/mysql/records?db=testdb");
+			const res = await app.request("/api/mysql/records?db=testdb");
 			expect(res.status).toBe(404);
 		});
 
 		it("should return 404 for PUT /mysql/records", async () => {
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "PUT",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({}),
@@ -690,7 +690,7 @@ describe("Records Routes (MySQL)", () => {
 		});
 
 		it("should return 404 for GET /mysql/records/force", async () => {
-			const res = await app.request("/mysql/records/force?db=testdb");
+			const res = await app.request("/api/mysql/records/force?db=testdb");
 			expect(res.status).toBe(404);
 		});
 	});
@@ -702,7 +702,7 @@ describe("Records Routes (MySQL)", () => {
 		it("should include CORS headers on POST", async () => {
 			mockDao.addRecord.mockResolvedValue({ insertedCount: 1 });
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", data: { name: "Test" } }),
@@ -714,7 +714,7 @@ describe("Records Routes (MySQL)", () => {
 		it("should return JSON content type", async () => {
 			mockDao.addRecord.mockResolvedValue({ insertedCount: 1 });
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "users", data: { name: "Test" } }),
@@ -732,7 +732,7 @@ describe("Records Routes (MySQL)", () => {
 			mockDao.addRecord.mockResolvedValue({ insertedCount: 1 });
 
 			const requests = Array.from({ length: 10 }, (_, i) =>
-				app.request("/mysql/records?db=testdb", {
+				app.request("/api/mysql/records?db=testdb", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ tableName: "users", data: { name: `User ${i}` } }),
@@ -766,7 +766,7 @@ describe("Records Routes (MySQL)", () => {
 				},
 			};
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),

--- a/packages/server/tests/routes/mysql/tables.routes.mysql.test.ts
+++ b/packages/server/tests/routes/mysql/tables.routes.mysql.test.ts
@@ -71,7 +71,7 @@ describe("Tables Routes (MySQL)", () => {
 
 			mockDao.getTablesList.mockResolvedValue(mockTables);
 
-			const res = await app.request("/mysql/tables?db=testdb");
+			const res = await app.request("/api/mysql/tables?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -82,7 +82,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should return empty array when no tables exist", async () => {
 			mockDao.getTablesList.mockResolvedValue([]);
 
-			const res = await app.request("/mysql/tables?db=testdb");
+			const res = await app.request("/api/mysql/tables?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -92,7 +92,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should handle single table response", async () => {
 			mockDao.getTablesList.mockResolvedValue([{ tableName: "only_table", rowCount: 10 }]);
 
-			const res = await app.request("/mysql/tables?db=testdb");
+			const res = await app.request("/api/mysql/tables?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -108,7 +108,7 @@ describe("Tables Routes (MySQL)", () => {
 
 			mockDao.getTablesList.mockResolvedValue(mockTables);
 
-			const res = await app.request("/mysql/tables?db=testdb");
+			const res = await app.request("/api/mysql/tables?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -116,7 +116,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/tables");
+			const res = await app.request("/api/mysql/tables");
 			expect(res.status).toBe(400);
 		});
 
@@ -125,14 +125,14 @@ describe("Tables Routes (MySQL)", () => {
 				new Error("Table 'information_schema.tables' doesn't exist"),
 			);
 
-			const res = await app.request("/mysql/tables?db=testdb");
+			const res = await app.request("/api/mysql/tables?db=testdb");
 			expect(res.status).toBe(500);
 		});
 
 		it("should return 503 when MySQL connection fails", async () => {
 			mockDao.getTablesList.mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:3306"));
 
-			const res = await app.request("/mysql/tables?db=testdb");
+			const res = await app.request("/api/mysql/tables?db=testdb");
 			expect(res.status).toBe(503);
 		});
 	});
@@ -153,7 +153,7 @@ describe("Tables Routes (MySQL)", () => {
 				],
 			};
 
-			const res = await app.request("/mysql/tables?db=testdb", {
+			const res = await app.request("/api/mysql/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -181,7 +181,7 @@ describe("Tables Routes (MySQL)", () => {
 				],
 			};
 
-			const res = await app.request("/mysql/tables?db=testdb", {
+			const res = await app.request("/api/mysql/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -211,7 +211,7 @@ describe("Tables Routes (MySQL)", () => {
 				],
 			};
 
-			const res = await app.request("/mysql/tables?db=testdb", {
+			const res = await app.request("/api/mysql/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -221,7 +221,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when tableName is missing", async () => {
-			const res = await app.request("/mysql/tables?db=testdb", {
+			const res = await app.request("/api/mysql/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ fields: [{ columnName: "id", columnType: "INT" }] }),
@@ -231,7 +231,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when fields array is missing", async () => {
-			const res = await app.request("/mysql/tables?db=testdb", {
+			const res = await app.request("/api/mysql/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "bad_table" }),
@@ -241,7 +241,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/tables", {
+			const res = await app.request("/api/mysql/tables", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "test_table", fields: [{ columnName: "id", columnType: "INT" }] }),
@@ -253,7 +253,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should return 500 when DAO throws database error", async () => {
 			mockDao.createTable.mockRejectedValue(new Error("Table 'new_users' already exists"));
 
-			const res = await app.request("/mysql/tables?db=testdb", {
+			const res = await app.request("/api/mysql/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "new_users", fields: [{ columnName: "id", columnType: "INT" }] }),
@@ -265,7 +265,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should return 503 when database connection fails", async () => {
 			mockDao.createTable.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mysql/tables?db=testdb", {
+			const res = await app.request("/api/mysql/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ tableName: "test_table", fields: [{ columnName: "id", columnType: "INT" }] }),
@@ -282,7 +282,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should delete a column and return 200", async () => {
 			mockDao.deleteColumn.mockResolvedValue({ deletedCount: 0 });
 
-			const res = await app.request("/mysql/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/email?db=testdb", {
 				method: "DELETE",
 			});
 
@@ -300,7 +300,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should delete a column with cascade option", async () => {
 			mockDao.deleteColumn.mockResolvedValue({ deletedCount: 5 });
 
-			const res = await app.request("/mysql/tables/orders/columns/user_id?db=testdb&cascade=true", {
+			const res = await app.request("/api/mysql/tables/orders/columns/user_id?db=testdb&cascade=true", {
 				method: "DELETE",
 			});
 
@@ -314,7 +314,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/tables/users/columns/email", { method: "DELETE" });
+			const res = await app.request("/api/mysql/tables/users/columns/email", { method: "DELETE" });
 			expect(res.status).toBe(400);
 		});
 
@@ -323,7 +323,7 @@ describe("Tables Routes (MySQL)", () => {
 				new HTTPException(404, { message: 'Table "nonexistent" does not exist' }),
 			);
 
-			const res = await app.request("/mysql/tables/nonexistent/columns/email?db=testdb", {
+			const res = await app.request("/api/mysql/tables/nonexistent/columns/email?db=testdb", {
 				method: "DELETE",
 			});
 
@@ -335,7 +335,7 @@ describe("Tables Routes (MySQL)", () => {
 				new HTTPException(404, { message: 'Column "nonexistent" does not exist in table "users"' }),
 			);
 
-			const res = await app.request("/mysql/tables/users/columns/nonexistent?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/nonexistent?db=testdb", {
 				method: "DELETE",
 			});
 
@@ -345,7 +345,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should return 503 when database connection fails", async () => {
 			mockDao.deleteColumn.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mysql/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/email?db=testdb", {
 				method: "DELETE",
 			});
 
@@ -371,7 +371,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should add a column and return 200", async () => {
 			mockDao.addColumn.mockResolvedValue(undefined);
 
-			const res = await app.request("/mysql/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -384,7 +384,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/tables/users/columns", {
+			const res = await app.request("/api/mysql/tables/users/columns", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -394,7 +394,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when request body is invalid", async () => {
-			const res = await app.request("/mysql/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ columnName: "email" }),
@@ -408,7 +408,7 @@ describe("Tables Routes (MySQL)", () => {
 				new HTTPException(404, { message: 'Table "users" does not exist' }),
 			);
 
-			const res = await app.request("/mysql/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -422,7 +422,7 @@ describe("Tables Routes (MySQL)", () => {
 				new HTTPException(409, { message: 'Column "email" already exists in table "users"' }),
 			);
 
-			const res = await app.request("/mysql/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -434,7 +434,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should return 503 when database connection fails", async () => {
 			mockDao.addColumn.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mysql/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -451,7 +451,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should rename a column and return 200", async () => {
 			mockDao.renameColumn.mockResolvedValue(undefined);
 
-			const res = await app.request("/mysql/tables/users/columns/email/rename?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/email/rename?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ newColumnName: "email_address" }),
@@ -469,7 +469,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/tables/users/columns/email/rename", {
+			const res = await app.request("/api/mysql/tables/users/columns/email/rename", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ newColumnName: "email_address" }),
@@ -479,7 +479,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when request body is invalid", async () => {
-			const res = await app.request("/mysql/tables/users/columns/email/rename?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/email/rename?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({}),
@@ -493,7 +493,7 @@ describe("Tables Routes (MySQL)", () => {
 				new HTTPException(404, { message: 'Column "email" does not exist in table "users"' }),
 			);
 
-			const res = await app.request("/mysql/tables/users/columns/email/rename?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/email/rename?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ newColumnName: "email_address" }),
@@ -507,7 +507,7 @@ describe("Tables Routes (MySQL)", () => {
 				new HTTPException(409, { message: 'Column "email_address" already exists in table "users"' }),
 			);
 
-			const res = await app.request("/mysql/tables/users/columns/email/rename?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/email/rename?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ newColumnName: "email_address" }),
@@ -519,7 +519,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should return 503 when database connection fails", async () => {
 			mockDao.renameColumn.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mysql/tables/users/columns/email/rename?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/email/rename?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ newColumnName: "email_address" }),
@@ -538,7 +538,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should alter a column and return 200", async () => {
 			mockDao.alterColumn.mockResolvedValue(undefined);
 
-			const res = await app.request("/mysql/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/email?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -556,7 +556,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/tables/users/columns/email", {
+			const res = await app.request("/api/mysql/tables/users/columns/email", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -566,7 +566,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when request body is invalid", async () => {
-			const res = await app.request("/mysql/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/email?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ isNullable: true }),
@@ -580,7 +580,7 @@ describe("Tables Routes (MySQL)", () => {
 				new HTTPException(404, { message: 'Column "email" does not exist in table "users"' }),
 			);
 
-			const res = await app.request("/mysql/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/email?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -592,7 +592,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should return 503 when database connection fails", async () => {
 			mockDao.alterColumn.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mysql/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/mysql/tables/users/columns/email?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -636,7 +636,7 @@ describe("Tables Routes (MySQL)", () => {
 
 			mockDao.getTableColumns.mockResolvedValue(mockColumns);
 
-			const res = await app.request("/mysql/tables/users/columns?db=testdb");
+			const res = await app.request("/api/mysql/tables/users/columns?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -662,7 +662,7 @@ describe("Tables Routes (MySQL)", () => {
 
 			mockDao.getTableColumns.mockResolvedValue(mockColumns);
 
-			const res = await app.request("/mysql/tables/orders/columns?db=testdb");
+			const res = await app.request("/api/mysql/tables/orders/columns?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -688,7 +688,7 @@ describe("Tables Routes (MySQL)", () => {
 
 			mockDao.getTableColumns.mockResolvedValue(mockColumns);
 
-			const res = await app.request("/mysql/tables/tasks/columns?db=testdb");
+			const res = await app.request("/api/mysql/tables/tasks/columns?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -713,7 +713,7 @@ describe("Tables Routes (MySQL)", () => {
 
 			mockDao.getTableColumns.mockResolvedValue(mockColumns);
 
-			const res = await app.request("/mysql/tables/users/columns?db=testdb");
+			const res = await app.request("/api/mysql/tables/users/columns?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -721,7 +721,7 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/tables/users/columns");
+			const res = await app.request("/api/mysql/tables/users/columns");
 			expect(res.status).toBe(400);
 		});
 
@@ -730,14 +730,14 @@ describe("Tables Routes (MySQL)", () => {
 				new HTTPException(404, { message: 'Table "nonexistent" does not exist' }),
 			);
 
-			const res = await app.request("/mysql/tables/nonexistent/columns?db=testdb");
+			const res = await app.request("/api/mysql/tables/nonexistent/columns?db=testdb");
 			expect(res.status).toBe(404);
 		});
 
 		it("should return 503 when database connection fails", async () => {
 			mockDao.getTableColumns.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mysql/tables/users/columns?db=testdb");
+			const res = await app.request("/api/mysql/tables/users/columns?db=testdb");
 			expect(res.status).toBe(503);
 		});
 	});
@@ -764,7 +764,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should return table data with default pagination", async () => {
 			mockDao.getTableData.mockResolvedValue(mockDataResponse);
 
-			const res = await app.request("/mysql/tables/users/data?db=testdb");
+			const res = await app.request("/api/mysql/tables/users/data?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -784,7 +784,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should handle custom limit parameter", async () => {
 			mockDao.getTableData.mockResolvedValue({ ...mockDataResponse, meta: { ...mockDataResponse.meta, limit: 25 } });
 
-			const res = await app.request("/mysql/tables/users/data?db=testdb&limit=25");
+			const res = await app.request("/api/mysql/tables/users/data?db=testdb&limit=25");
 
 			expect(res.status).toBe(200);
 			expect(mockDao.getTableData).toHaveBeenCalledWith(expect.objectContaining({ limit: 25 }));
@@ -794,7 +794,7 @@ describe("Tables Routes (MySQL)", () => {
 			const cursor = "eyJ2YWx1ZXMiOnsiaWQiOjEwfSwic29ydENvbHVtbnMiOlsiaWQiXX0";
 			mockDao.getTableData.mockResolvedValue(mockDataResponse);
 
-			const res = await app.request(`/mysql/tables/users/data?db=testdb&cursor=${cursor}&direction=asc`);
+			const res = await app.request(`/api/mysql/tables/users/data?db=testdb&cursor=${cursor}&direction=asc`);
 
 			expect(res.status).toBe(200);
 			expect(mockDao.getTableData).toHaveBeenCalledWith(expect.objectContaining({ cursor, direction: "asc" }));
@@ -804,7 +804,7 @@ describe("Tables Routes (MySQL)", () => {
 			const cursor = "eyJ2YWx1ZXMiOnsiaWQiOjEwfSwic29ydENvbHVtbnMiOlsiaWQiXX0";
 			mockDao.getTableData.mockResolvedValue(mockDataResponse);
 
-			const res = await app.request(`/mysql/tables/users/data?db=testdb&cursor=${cursor}&direction=desc`);
+			const res = await app.request(`/api/mysql/tables/users/data?db=testdb&cursor=${cursor}&direction=desc`);
 
 			expect(res.status).toBe(200);
 			expect(mockDao.getTableData).toHaveBeenCalledWith(expect.objectContaining({ cursor, direction: "desc" }));
@@ -813,7 +813,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should handle single column sort", async () => {
 			mockDao.getTableData.mockResolvedValue(mockDataResponse);
 
-			const res = await app.request("/mysql/tables/users/data?db=testdb&sort=name&order=asc");
+			const res = await app.request("/api/mysql/tables/users/data?db=testdb&sort=name&order=asc");
 
 			expect(res.status).toBe(200);
 			expect(mockDao.getTableData).toHaveBeenCalledWith(expect.objectContaining({ sort: "name", order: "asc" }));
@@ -827,7 +827,7 @@ describe("Tables Routes (MySQL)", () => {
 				{ columnName: "created_at", direction: "desc" },
 			]);
 
-			const res = await app.request(`/mysql/tables/users/data?db=testdb&sort=${encodeURIComponent(sortArray)}`);
+			const res = await app.request(`/api/mysql/tables/users/data?db=testdb&sort=${encodeURIComponent(sortArray)}`);
 
 			expect(res.status).toBe(200);
 			expect(mockDao.getTableData).toHaveBeenCalledWith(
@@ -842,7 +842,7 @@ describe("Tables Routes (MySQL)", () => {
 
 			const filters = JSON.stringify([{ columnName: "name", operator: "=", value: "John" }]);
 
-			const res = await app.request(`/mysql/tables/users/data?db=testdb&filters=${encodeURIComponent(filters)}`);
+			const res = await app.request(`/api/mysql/tables/users/data?db=testdb&filters=${encodeURIComponent(filters)}`);
 
 			expect(res.status).toBe(200);
 			expect(mockDao.getTableData).toHaveBeenCalledWith(
@@ -855,7 +855,7 @@ describe("Tables Routes (MySQL)", () => {
 
 			const filters = JSON.stringify([{ columnName: "name", operator: "LIKE", value: "%john%" }]);
 
-			const res = await app.request(`/mysql/tables/users/data?db=testdb&filters=${encodeURIComponent(filters)}`);
+			const res = await app.request(`/api/mysql/tables/users/data?db=testdb&filters=${encodeURIComponent(filters)}`);
 
 			expect(res.status).toBe(200);
 		});
@@ -866,7 +866,7 @@ describe("Tables Routes (MySQL)", () => {
 				meta: { limit: 50, total: 0, hasNextPage: false, hasPreviousPage: false, nextCursor: null, prevCursor: null },
 			});
 
-			const res = await app.request("/mysql/tables/empty_table/data?db=testdb");
+			const res = await app.request("/api/mysql/tables/empty_table/data?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -875,26 +875,26 @@ describe("Tables Routes (MySQL)", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/mysql/tables/users/data");
+			const res = await app.request("/api/mysql/tables/users/data");
 			expect(res.status).toBe(400);
 		});
 
 		it("should return 400 for invalid direction parameter", async () => {
-			const res = await app.request("/mysql/tables/users/data?db=testdb&direction=invalid");
+			const res = await app.request("/api/mysql/tables/users/data?db=testdb&direction=invalid");
 			expect(res.status).toBe(400);
 		});
 
 		it("should return 503 when database connection fails", async () => {
 			mockDao.getTableData.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/mysql/tables/users/data?db=testdb");
+			const res = await app.request("/api/mysql/tables/users/data?db=testdb");
 			expect(res.status).toBe(503);
 		});
 
 		it("should return 500 when DAO throws generic error", async () => {
 			mockDao.getTableData.mockRejectedValue(new Error("Unexpected error"));
 
-			const res = await app.request("/mysql/tables/users/data?db=testdb");
+			const res = await app.request("/api/mysql/tables/users/data?db=testdb");
 			expect(res.status).toBe(500);
 		});
 	});
@@ -904,17 +904,17 @@ describe("Tables Routes (MySQL)", () => {
 	// ============================================
 	describe("Invalid database type validation", () => {
 		it("should return 400 for invalid database type", async () => {
-			const res = await app.request("/invalid/tables?db=testdb");
+			const res = await app.request("/api/invalid/tables?db=testdb");
 			expect(res.status).toBe(400);
 		});
 
 		it("should return 400 for sqlite database type (not supported)", async () => {
-			const res = await app.request("/sqlite/tables?db=testdb");
+			const res = await app.request("/api/sqlite/tables?db=testdb");
 			expect(res.status).toBe(400);
 		});
 
 		it("should return 400 for numeric database type", async () => {
-			const res = await app.request("/123/tables?db=testdb");
+			const res = await app.request("/api/123/tables?db=testdb");
 			expect(res.status).toBe(400);
 		});
 	});
@@ -926,14 +926,14 @@ describe("Tables Routes (MySQL)", () => {
 		it("should include CORS headers", async () => {
 			mockDao.getTablesList.mockResolvedValue([{ tableName: "test", rowCount: 0 }]);
 
-			const res = await app.request("/mysql/tables?db=testdb");
+			const res = await app.request("/api/mysql/tables?db=testdb");
 			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
 		});
 
 		it("should return JSON content type", async () => {
 			mockDao.getTablesList.mockResolvedValue([{ tableName: "test", rowCount: 0 }]);
 
-			const res = await app.request("/mysql/tables?db=testdb");
+			const res = await app.request("/api/mysql/tables?db=testdb");
 			expect(res.headers.get("Content-Type")).toContain("application/json");
 		});
 	});
@@ -945,7 +945,7 @@ describe("Tables Routes (MySQL)", () => {
 		it("should handle multiple concurrent requests to /tables", async () => {
 			mockDao.getTablesList.mockResolvedValue([{ tableName: "users", rowCount: 100 }]);
 
-			const requests = Array.from({ length: 10 }, () => app.request("/mysql/tables?db=testdb"));
+			const requests = Array.from({ length: 10 }, () => app.request("/api/mysql/tables?db=testdb"));
 			const responses = await Promise.all(requests);
 
 			for (const res of responses) {
@@ -962,13 +962,13 @@ describe("Tables Routes (MySQL)", () => {
 		it("should handle table names with underscores", async () => {
 			mockDao.getTableColumns.mockResolvedValue([]);
 
-			const res = await app.request("/mysql/tables/user_profiles/columns?db=testdb");
+			const res = await app.request("/api/mysql/tables/user_profiles/columns?db=testdb");
 
 			expect(mockDao.getTableColumns).toHaveBeenCalledWith({ tableName: "user_profiles", db: "testdb" });
 		});
 
 		it("should return 404 for non-existent sub-routes", async () => {
-			const res = await app.request("/mysql/tables/users/nonexistent?db=testdb");
+			const res = await app.request("/api/mysql/tables/users/nonexistent?db=testdb");
 			expect(res.status).toBe(404);
 		});
 	});

--- a/packages/server/tests/routes/query.routes.test.ts
+++ b/packages/server/tests/routes/query.routes.test.ts
@@ -79,7 +79,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT * FROM users" }),
@@ -104,7 +104,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -128,7 +128,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -152,7 +152,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -176,7 +176,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -204,7 +204,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT * FROM users LIMIT 1000" }),
@@ -244,7 +244,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT * FROM complex_table" }),
@@ -270,7 +270,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -295,7 +295,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -320,7 +320,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "DROP TABLE IF EXISTS test_table" }),
@@ -342,7 +342,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -368,7 +368,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -393,7 +393,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -417,7 +417,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1 as id" }),
@@ -432,7 +432,7 @@ describe("Query Routes", () => {
 		// Validation errors
 		// ============================================
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/pg/query", {
+			const res = await app.request("/api/pg/query", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT * FROM users" }),
@@ -442,7 +442,7 @@ describe("Query Routes", () => {
 		});
 
 		it("should return 400 when query is missing from body", async () => {
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({}),
@@ -452,7 +452,7 @@ describe("Query Routes", () => {
 		});
 
 		it("should return 400 when body is empty", async () => {
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: "",
@@ -462,7 +462,7 @@ describe("Query Routes", () => {
 		});
 
 		it("should return 400 when body is invalid JSON", async () => {
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: "invalid json",
@@ -472,7 +472,7 @@ describe("Query Routes", () => {
 		});
 
 		it("should return 400 when query is not a string", async () => {
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: 123 }),
@@ -486,7 +486,7 @@ describe("Query Routes", () => {
 				new HTTPException(400, { message: "Query is required" })
 			);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "" }),
@@ -500,7 +500,7 @@ describe("Query Routes", () => {
 				new HTTPException(400, { message: "Query is required" })
 			);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "   " }),
@@ -517,7 +517,7 @@ describe("Query Routes", () => {
 				new Error('syntax error at or near "SELEC"')
 			);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELEC * FROM users" }),
@@ -531,7 +531,7 @@ describe("Query Routes", () => {
 				new Error('relation "nonexistent_table" does not exist')
 			);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT * FROM nonexistent_table" }),
@@ -545,7 +545,7 @@ describe("Query Routes", () => {
 				new Error('column "nonexistent_column" does not exist')
 			);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -561,7 +561,7 @@ describe("Query Routes", () => {
 				new Error("duplicate key value violates unique constraint")
 			);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -578,7 +578,7 @@ describe("Query Routes", () => {
 				new Error("violates foreign key constraint")
 			);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -594,7 +594,7 @@ describe("Query Routes", () => {
 				new Error("connect ECONNREFUSED 127.0.0.1:5432")
 			);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -610,7 +610,7 @@ describe("Query Routes", () => {
 				new Error("timeout expired")
 			);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -624,7 +624,7 @@ describe("Query Routes", () => {
 				new HTTPException(500, { message: "Internal server error" })
 			);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -639,7 +639,7 @@ describe("Query Routes", () => {
 	// ============================================
 	describe("Invalid database type validation", () => {
 		it("should return 400 for invalid database type", async () => {
-			const res = await app.request("/invalid/query?db=testdb", {
+			const res = await app.request("/api/invalid/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -656,7 +656,7 @@ describe("Query Routes", () => {
 				duration: 1.0,
 			});
 
-			const res = await app.request("/mysql/query?db=testdb", {
+			const res = await app.request("/api/mysql/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -667,7 +667,7 @@ describe("Query Routes", () => {
 		});
 
 		it("should return 400 for sqlite database type (not supported)", async () => {
-			const res = await app.request("/sqlite/query?db=testdb", {
+			const res = await app.request("/api/sqlite/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -682,13 +682,13 @@ describe("Query Routes", () => {
 	// ============================================
 	describe("HTTP methods validation", () => {
 		it("should return 404 for GET /query", async () => {
-			const res = await app.request("/pg/query?db=testdb");
+			const res = await app.request("/api/pg/query?db=testdb");
 
 			expect(res.status).toBe(404);
 		});
 
 		it("should return 404 for PUT /query", async () => {
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "PUT",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -698,7 +698,7 @@ describe("Query Routes", () => {
 		});
 
 		it("should return 404 for DELETE /query", async () => {
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "DELETE",
 			});
 
@@ -706,7 +706,7 @@ describe("Query Routes", () => {
 		});
 
 		it("should return 404 for PATCH /query", async () => {
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1" }),
@@ -728,7 +728,7 @@ describe("Query Routes", () => {
 				duration: 1.0,
 			});
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1 as id" }),
@@ -745,7 +745,7 @@ describe("Query Routes", () => {
 				duration: 1.0,
 			});
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1 as id" }),
@@ -768,7 +768,7 @@ describe("Query Routes", () => {
 			});
 
 			const requests = Array.from({ length: 10 }, () =>
-				app.request("/pg/query?db=testdb", {
+				app.request("/api/pg/query?db=testdb", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ query: "SELECT 1 as id" }),
@@ -803,12 +803,12 @@ describe("Query Routes", () => {
 			});
 
 			const [res1, res2] = await Promise.all([
-				app.request("/pg/query?db=testdb", {
+				app.request("/api/pg/query?db=testdb", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ query: "SELECT * FROM users" }),
 				}),
-				app.request("/pg/query?db=testdb", {
+				app.request("/api/pg/query?db=testdb", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ query: "SELECT * FROM orders" }),
@@ -840,7 +840,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -863,7 +863,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -893,7 +893,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: longQuery }),
@@ -912,7 +912,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -933,7 +933,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1 as id;" }),
@@ -952,7 +952,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ query: "SELECT 1 as id;;;" }),
@@ -971,7 +971,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -992,7 +992,7 @@ describe("Query Routes", () => {
 
 			mockDao.executeQuery.mockResolvedValue(mockResult);
 
-			const res = await app.request("/pg/query?db=testdb", {
+			const res = await app.request("/api/pg/query?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({

--- a/packages/server/tests/routes/records.routes.test.ts
+++ b/packages/server/tests/routes/records.routes.test.ts
@@ -77,7 +77,7 @@ describe("Records Routes", () => {
 				},
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -114,7 +114,7 @@ describe("Records Routes", () => {
 				},
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -137,7 +137,7 @@ describe("Records Routes", () => {
 				},
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -158,7 +158,7 @@ describe("Records Routes", () => {
 				},
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -172,7 +172,7 @@ describe("Records Routes", () => {
 				data: { name: "Test" },
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -186,7 +186,7 @@ describe("Records Routes", () => {
 				tableName: "users",
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -201,7 +201,7 @@ describe("Records Routes", () => {
 				data: { name: "Test" },
 			};
 
-			const res = await app.request("/pg/records", {
+			const res = await app.request("/api/pg/records", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -222,7 +222,7 @@ describe("Records Routes", () => {
 				data: { name: "Test" },
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -241,7 +241,7 @@ describe("Records Routes", () => {
 				data: { name: "Test" },
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -260,7 +260,7 @@ describe("Records Routes", () => {
 				data: { user_id: 1, bio: "Hello" },
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -291,7 +291,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -328,7 +328,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -364,7 +364,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -391,7 +391,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -423,7 +423,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -449,7 +449,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -475,7 +475,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -501,7 +501,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -522,7 +522,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -538,7 +538,7 @@ describe("Records Routes", () => {
 				updates: [],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -553,7 +553,7 @@ describe("Records Routes", () => {
 				primaryKey: "id",
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -574,7 +574,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -595,7 +595,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -617,7 +617,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records", {
+			const res = await app.request("/api/pg/records", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -645,7 +645,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -674,7 +674,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -702,7 +702,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -728,7 +728,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -754,7 +754,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -790,7 +790,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -813,7 +813,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "sku", value: "PROD-123" }],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -839,7 +839,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -853,7 +853,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -868,7 +868,7 @@ describe("Records Routes", () => {
 				primaryKeys: [],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -882,7 +882,7 @@ describe("Records Routes", () => {
 				tableName: "users",
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -897,7 +897,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/pg/records", {
+			const res = await app.request("/api/pg/records", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -912,7 +912,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ value: 1 }],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -943,7 +943,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -977,7 +977,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -996,7 +996,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1020,7 +1020,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/pg/records/force?db=testdb", {
+			const res = await app.request("/api/pg/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1049,7 +1049,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records/force?db=testdb", {
+			const res = await app.request("/api/pg/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1065,7 +1065,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/pg/records/force?db=testdb", {
+			const res = await app.request("/api/pg/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1080,7 +1080,7 @@ describe("Records Routes", () => {
 				primaryKeys: [],
 			};
 
-			const res = await app.request("/pg/records/force?db=testdb", {
+			const res = await app.request("/api/pg/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1095,7 +1095,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/pg/records/force", {
+			const res = await app.request("/api/pg/records/force", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1116,7 +1116,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/pg/records/force?db=testdb", {
+			const res = await app.request("/api/pg/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1135,7 +1135,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/pg/records/force?db=testdb", {
+			const res = await app.request("/api/pg/records/force?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1155,7 +1155,7 @@ describe("Records Routes", () => {
 				data: { name: "Test" },
 			};
 
-			const res = await app.request("/invalid/records?db=testdb", {
+			const res = await app.request("/api/invalid/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1179,7 +1179,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/mysql/records?db=testdb", {
+			const res = await app.request("/api/mysql/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1195,7 +1195,7 @@ describe("Records Routes", () => {
 				primaryKeys: [{ columnName: "id", value: 1 }],
 			};
 
-			const res = await app.request("/sqlite/records?db=testdb", {
+			const res = await app.request("/api/sqlite/records?db=testdb", {
 				method: "DELETE",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1210,13 +1210,13 @@ describe("Records Routes", () => {
 	// ============================================
 	describe("HTTP methods validation", () => {
 		it("should return 404 for GET /records", async () => {
-			const res = await app.request("/pg/records?db=testdb");
+			const res = await app.request("/api/pg/records?db=testdb");
 
 			expect(res.status).toBe(404);
 		});
 
 		it("should return 404 for PUT /records", async () => {
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PUT",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({}),
@@ -1226,13 +1226,13 @@ describe("Records Routes", () => {
 		});
 
 		it("should return 404 for GET /records/force", async () => {
-			const res = await app.request("/pg/records/force?db=testdb");
+			const res = await app.request("/api/pg/records/force?db=testdb");
 
 			expect(res.status).toBe(404);
 		});
 
 		it("should return 404 for POST /records/force", async () => {
-			const res = await app.request("/pg/records/force?db=testdb", {
+			const res = await app.request("/api/pg/records/force?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({}),
@@ -1249,7 +1249,7 @@ describe("Records Routes", () => {
 		it("should include CORS headers on POST", async () => {
 			mockDao.addRecord.mockResolvedValue({ insertedCount: 1 });
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -1264,7 +1264,7 @@ describe("Records Routes", () => {
 		it("should return JSON content type", async () => {
 			mockDao.addRecord.mockResolvedValue({ insertedCount: 1 });
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -1285,7 +1285,7 @@ describe("Records Routes", () => {
 			mockDao.addRecord.mockResolvedValue({ insertedCount: 1 });
 
 			const requests = Array.from({ length: 10 }, (_, i) =>
-				app.request("/pg/records?db=testdb", {
+				app.request("/api/pg/records?db=testdb", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({
@@ -1316,7 +1316,7 @@ describe("Records Routes", () => {
 			});
 
 			const [res1, res2, res3] = await Promise.all([
-				app.request("/pg/records?db=testdb", {
+				app.request("/api/pg/records?db=testdb", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({
@@ -1324,7 +1324,7 @@ describe("Records Routes", () => {
 						data: { name: "New User" },
 					}),
 				}),
-				app.request("/pg/records?db=testdb", {
+				app.request("/api/pg/records?db=testdb", {
 					method: "PATCH",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({
@@ -1339,7 +1339,7 @@ describe("Records Routes", () => {
 						],
 					}),
 				}),
-				app.request("/pg/records?db=testdb", {
+				app.request("/api/pg/records?db=testdb", {
 					method: "DELETE",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({
@@ -1367,7 +1367,7 @@ describe("Records Routes", () => {
 				data: {},
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1386,7 +1386,7 @@ describe("Records Routes", () => {
 				data: { bio: longString },
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1407,7 +1407,7 @@ describe("Records Routes", () => {
 				},
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1430,7 +1430,7 @@ describe("Records Routes", () => {
 				},
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1450,7 +1450,7 @@ describe("Records Routes", () => {
 				},
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1477,7 +1477,7 @@ describe("Records Routes", () => {
 				},
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1494,7 +1494,7 @@ describe("Records Routes", () => {
 				data: { user_id: 1 },
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1524,7 +1524,7 @@ describe("Records Routes", () => {
 				},
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -1565,7 +1565,7 @@ describe("Records Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/records?db=testdb", {
+			const res = await app.request("/api/pg/records?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),

--- a/packages/server/tests/routes/tables.routes.test.ts
+++ b/packages/server/tests/routes/tables.routes.test.ts
@@ -76,7 +76,7 @@ describe("Tables Routes", () => {
 
 			mockDao.getTablesList.mockResolvedValue(mockTables);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -89,7 +89,7 @@ describe("Tables Routes", () => {
 
 			mockDao.getTablesList.mockResolvedValue(mockTables);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -105,7 +105,7 @@ describe("Tables Routes", () => {
 
 			mockDao.getTablesList.mockResolvedValue(mockTables);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -121,7 +121,7 @@ describe("Tables Routes", () => {
 
 			mockDao.getTablesList.mockResolvedValue(mockTables);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -136,7 +136,7 @@ describe("Tables Routes", () => {
 
 			mockDao.getTablesList.mockResolvedValue(mockTables);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -151,7 +151,7 @@ describe("Tables Routes", () => {
 
 			mockDao.getTablesList.mockResolvedValue(mockTables);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -159,7 +159,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/pg/tables");
+			const res = await app.request("/api/pg/tables");
 
 			expect(res.status).toBe(400);
 		});
@@ -169,7 +169,7 @@ describe("Tables Routes", () => {
 				new HTTPException(500, { message: "No tables returned from database" })
 			);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			expect(res.status).toBe(500);
 		});
@@ -178,7 +178,7 @@ describe("Tables Routes", () => {
 			const connectionError = new Error("connect ECONNREFUSED 127.0.0.1:5432");
 			mockDao.getTablesList.mockRejectedValue(connectionError);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			expect(res.status).toBe(503);
 			const json = await res.json();
@@ -189,7 +189,7 @@ describe("Tables Routes", () => {
 			const timeoutError = new Error("timeout expired");
 			mockDao.getTablesList.mockRejectedValue(timeoutError);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			expect(res.status).toBe(503);
 		});
@@ -219,7 +219,7 @@ describe("Tables Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -268,7 +268,7 @@ describe("Tables Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -308,7 +308,7 @@ describe("Tables Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -356,7 +356,7 @@ describe("Tables Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -370,7 +370,7 @@ describe("Tables Routes", () => {
 				fields: [{ columnName: "id", columnType: "SERIAL" }],
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -385,7 +385,7 @@ describe("Tables Routes", () => {
 				fields: [],
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -399,7 +399,7 @@ describe("Tables Routes", () => {
 				tableName: "no_fields_table",
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -414,7 +414,7 @@ describe("Tables Routes", () => {
 				fields: [{ columnType: "SERIAL" }],
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -429,7 +429,7 @@ describe("Tables Routes", () => {
 				fields: [{ columnName: "id" }],
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -444,7 +444,7 @@ describe("Tables Routes", () => {
 				fields: [{ columnName: "id", columnType: "SERIAL" }],
 			};
 
-			const res = await app.request("/pg/tables", {
+			const res = await app.request("/api/pg/tables", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -471,7 +471,7 @@ describe("Tables Routes", () => {
 				],
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -490,7 +490,7 @@ describe("Tables Routes", () => {
 				fields: [{ columnName: "id", columnType: "SERIAL" }],
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -509,7 +509,7 @@ describe("Tables Routes", () => {
 				fields: [{ columnName: "id", columnType: "SERIAL" }],
 			};
 
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -526,7 +526,7 @@ describe("Tables Routes", () => {
 		it("should delete a column and return 200", async () => {
 			mockDao.deleteColumn.mockResolvedValue({ deletedCount: 0 });
 
-			const res = await app.request("/pg/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns/email?db=testdb", {
 				method: "DELETE",
 			});
 
@@ -547,7 +547,7 @@ describe("Tables Routes", () => {
 			mockDao.deleteColumn.mockResolvedValue({ deletedCount: 0 });
 
 			const res = await app.request(
-				"/pg/tables/orders/columns/user_id?db=testdb&cascade=true",
+				"/api/pg/tables/orders/columns/user_id?db=testdb&cascade=true",
 				{ method: "DELETE" }
 			);
 
@@ -564,7 +564,7 @@ describe("Tables Routes", () => {
 			mockDao.deleteColumn.mockResolvedValue({ deletedCount: 0 });
 
 			const res = await app.request(
-				"/pg/tables/products/columns/name?db=testdb&cascade=false",
+				"/api/pg/tables/products/columns/name?db=testdb&cascade=false",
 				{ method: "DELETE" }
 			);
 
@@ -581,7 +581,7 @@ describe("Tables Routes", () => {
 			mockDao.deleteColumn.mockResolvedValue({ deletedCount: 0 });
 
 			const res = await app.request(
-				"/pg/tables/users/columns/created_at?db=testdb",
+				"/api/pg/tables/users/columns/created_at?db=testdb",
 				{ method: "DELETE" }
 			);
 
@@ -593,7 +593,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/pg/tables/users/columns/email", {
+			const res = await app.request("/api/pg/tables/users/columns/email", {
 				method: "DELETE",
 			});
 
@@ -606,7 +606,7 @@ describe("Tables Routes", () => {
 			);
 
 			const res = await app.request(
-				"/pg/tables/nonexistent/columns/email?db=testdb",
+				"/api/pg/tables/nonexistent/columns/email?db=testdb",
 				{ method: "DELETE" }
 			);
 
@@ -621,7 +621,7 @@ describe("Tables Routes", () => {
 			);
 
 			const res = await app.request(
-				"/pg/tables/users/columns/nonexistent?db=testdb",
+				"/api/pg/tables/users/columns/nonexistent?db=testdb",
 				{ method: "DELETE" }
 			);
 
@@ -634,7 +634,7 @@ describe("Tables Routes", () => {
 			);
 
 			const res = await app.request(
-				"/pg/tables/users/columns/id?db=testdb&cascade=false",
+				"/api/pg/tables/users/columns/id?db=testdb&cascade=false",
 				{ method: "DELETE" }
 			);
 
@@ -647,7 +647,7 @@ describe("Tables Routes", () => {
 			);
 
 			const res = await app.request(
-				"/pg/tables/users/columns/email?db=testdb",
+				"/api/pg/tables/users/columns/email?db=testdb",
 				{ method: "DELETE" }
 			);
 
@@ -673,7 +673,7 @@ describe("Tables Routes", () => {
 		it("should add a column and return 200", async () => {
 			mockDao.addColumn.mockResolvedValue();
 
-			const res = await app.request("/pg/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -690,7 +690,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/pg/tables/users/columns", {
+			const res = await app.request("/api/pg/tables/users/columns", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -700,7 +700,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 400 when request body is invalid", async () => {
-			const res = await app.request("/pg/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -716,7 +716,7 @@ describe("Tables Routes", () => {
 				new HTTPException(404, { message: 'Table "users" does not exist' }),
 			);
 
-			const res = await app.request("/pg/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -732,7 +732,7 @@ describe("Tables Routes", () => {
 				}),
 			);
 
-			const res = await app.request("/pg/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -744,7 +744,7 @@ describe("Tables Routes", () => {
 		it("should return 503 when database connection fails", async () => {
 			mockDao.addColumn.mockRejectedValue(new Error("connect ECONNREFUSED"));
 
-			const res = await app.request("/pg/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns?db=testdb", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -761,7 +761,7 @@ describe("Tables Routes", () => {
 		it("should rename a column and return 200", async () => {
 			mockDao.renameColumn.mockResolvedValue();
 
-			const res = await app.request("/pg/tables/users/columns/email/rename?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns/email/rename?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ newColumnName: "email_address" }),
@@ -781,7 +781,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/pg/tables/users/columns/email/rename", {
+			const res = await app.request("/api/pg/tables/users/columns/email/rename", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ newColumnName: "email_address" }),
@@ -791,7 +791,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 400 when request body is invalid", async () => {
-			const res = await app.request("/pg/tables/users/columns/email/rename?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns/email/rename?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({}),
@@ -807,7 +807,7 @@ describe("Tables Routes", () => {
 				}),
 			);
 
-			const res = await app.request("/pg/tables/users/columns/email/rename?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns/email/rename?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ newColumnName: "email_address" }),
@@ -823,7 +823,7 @@ describe("Tables Routes", () => {
 				}),
 			);
 
-			const res = await app.request("/pg/tables/users/columns/email/rename?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns/email/rename?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ newColumnName: "email_address" }),
@@ -837,7 +837,7 @@ describe("Tables Routes", () => {
 				new Error("connect ECONNREFUSED"),
 			);
 
-			const res = await app.request("/pg/tables/users/columns/email/rename?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns/email/rename?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ newColumnName: "email_address" }),
@@ -860,7 +860,7 @@ describe("Tables Routes", () => {
 		it("should alter a column and return 200", async () => {
 			mockDao.alterColumn.mockResolvedValue();
 
-			const res = await app.request("/pg/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns/email?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -878,7 +878,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/pg/tables/users/columns/email", {
+			const res = await app.request("/api/pg/tables/users/columns/email", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -888,7 +888,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 400 when request body is invalid", async () => {
-			const res = await app.request("/pg/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns/email?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ isNullable: true }),
@@ -904,7 +904,7 @@ describe("Tables Routes", () => {
 				}),
 			);
 
-			const res = await app.request("/pg/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns/email?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -918,7 +918,7 @@ describe("Tables Routes", () => {
 				new Error("connect ECONNREFUSED"),
 			);
 
-			const res = await app.request("/pg/tables/users/columns/email?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns/email?db=testdb", {
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(body),
@@ -962,7 +962,7 @@ describe("Tables Routes", () => {
 
 			mockDao.getTableColumns.mockResolvedValue(mockColumns);
 
-			const res = await app.request("/pg/tables/users/columns?db=testdb");
+			const res = await app.request("/api/pg/tables/users/columns?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -1003,7 +1003,7 @@ describe("Tables Routes", () => {
 
 			mockDao.getTableColumns.mockResolvedValue(mockColumns);
 
-			const res = await app.request("/pg/tables/orders/columns?db=testdb");
+			const res = await app.request("/api/pg/tables/orders/columns?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -1029,7 +1029,7 @@ describe("Tables Routes", () => {
 
 			mockDao.getTableColumns.mockResolvedValue(mockColumns);
 
-			const res = await app.request("/pg/tables/tasks/columns?db=testdb");
+			const res = await app.request("/api/pg/tables/tasks/columns?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -1071,7 +1071,7 @@ describe("Tables Routes", () => {
 
 			mockDao.getTableColumns.mockResolvedValue(mockColumns);
 
-			const res = await app.request("/pg/tables/users/columns?db=testdb");
+			const res = await app.request("/api/pg/tables/users/columns?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -1091,7 +1091,7 @@ describe("Tables Routes", () => {
 
 			mockDao.getTableColumns.mockResolvedValue(mockColumns);
 
-			const res = await app.request("/pg/tables/users/columns?db=testdb");
+			const res = await app.request("/api/pg/tables/users/columns?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -1099,7 +1099,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/pg/tables/users/columns");
+			const res = await app.request("/api/pg/tables/users/columns");
 
 			expect(res.status).toBe(400);
 		});
@@ -1110,7 +1110,7 @@ describe("Tables Routes", () => {
 			);
 
 			const res = await app.request(
-				"/pg/tables/nonexistent/columns?db=testdb"
+				"/api/pg/tables/nonexistent/columns?db=testdb"
 			);
 
 			expect(res.status).toBe(404);
@@ -1121,7 +1121,7 @@ describe("Tables Routes", () => {
 				new Error("connect ECONNREFUSED")
 			);
 
-			const res = await app.request("/pg/tables/users/columns?db=testdb");
+			const res = await app.request("/api/pg/tables/users/columns?db=testdb");
 
 			expect(res.status).toBe(503);
 		});
@@ -1149,7 +1149,7 @@ describe("Tables Routes", () => {
 		it("should return table data with default pagination", async () => {
 			mockDao.getTableData.mockResolvedValue(mockDataResponse);
 
-			const res = await app.request("/pg/tables/users/data?db=testdb");
+			const res = await app.request("/api/pg/tables/users/data?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -1173,7 +1173,7 @@ describe("Tables Routes", () => {
 			});
 
 			const res = await app.request(
-				"/pg/tables/users/data?db=testdb&limit=25"
+				"/api/pg/tables/users/data?db=testdb&limit=25"
 			);
 
 			expect(res.status).toBe(200);
@@ -1194,7 +1194,7 @@ describe("Tables Routes", () => {
 			});
 
 			const res = await app.request(
-				`/pg/tables/users/data?db=testdb&cursor=${cursor}&direction=asc`
+				`/api/pg/tables/users/data?db=testdb&cursor=${cursor}&direction=asc`
 			);
 
 			expect(res.status).toBe(200);
@@ -1218,7 +1218,7 @@ describe("Tables Routes", () => {
 			});
 
 			const res = await app.request(
-				`/pg/tables/users/data?db=testdb&cursor=${cursor}&direction=desc`
+				`/api/pg/tables/users/data?db=testdb&cursor=${cursor}&direction=desc`
 			);
 
 			expect(res.status).toBe(200);
@@ -1234,7 +1234,7 @@ describe("Tables Routes", () => {
 			mockDao.getTableData.mockResolvedValue(mockDataResponse);
 
 			const res = await app.request(
-				"/pg/tables/users/data?db=testdb&sort=name&order=asc"
+				"/api/pg/tables/users/data?db=testdb&sort=name&order=asc"
 			);
 
 			expect(res.status).toBe(200);
@@ -1255,7 +1255,7 @@ describe("Tables Routes", () => {
 			]);
 
 			const res = await app.request(
-				`/pg/tables/users/data?db=testdb&sort=${encodeURIComponent(sortArray)}`
+				`/api/pg/tables/users/data?db=testdb&sort=${encodeURIComponent(sortArray)}`
 			);
 
 			expect(res.status).toBe(200);
@@ -1273,7 +1273,7 @@ describe("Tables Routes", () => {
 			mockDao.getTableData.mockResolvedValue(mockDataResponse);
 
 			const res = await app.request(
-				"/pg/tables/users/data?db=testdb&sort=id&order=desc"
+				"/api/pg/tables/users/data?db=testdb&sort=id&order=desc"
 			);
 
 			expect(res.status).toBe(200);
@@ -1297,7 +1297,7 @@ describe("Tables Routes", () => {
 			]);
 
 			const res = await app.request(
-				`/pg/tables/users/data?db=testdb&filters=${encodeURIComponent(filters)}`
+				`/api/pg/tables/users/data?db=testdb&filters=${encodeURIComponent(filters)}`
 			);
 
 			expect(res.status).toBe(200);
@@ -1318,7 +1318,7 @@ describe("Tables Routes", () => {
 			]);
 
 			const res = await app.request(
-				`/pg/tables/users/data?db=testdb&filters=${encodeURIComponent(filters)}`
+				`/api/pg/tables/users/data?db=testdb&filters=${encodeURIComponent(filters)}`
 			);
 
 			expect(res.status).toBe(200);
@@ -1341,7 +1341,7 @@ describe("Tables Routes", () => {
 			]);
 
 			const res = await app.request(
-				`/pg/tables/users/data?db=testdb&sort=name&order=asc&filters=${encodeURIComponent(filters)}`
+				`/api/pg/tables/users/data?db=testdb&sort=name&order=asc&filters=${encodeURIComponent(filters)}`
 			);
 
 			expect(res.status).toBe(200);
@@ -1367,7 +1367,7 @@ describe("Tables Routes", () => {
 				},
 			});
 
-			const res = await app.request("/pg/tables/empty_table/data?db=testdb");
+			const res = await app.request("/api/pg/tables/empty_table/data?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -1391,7 +1391,7 @@ describe("Tables Routes", () => {
 				},
 			});
 
-			const res = await app.request("/pg/tables/users/data?db=testdb");
+			const res = await app.request("/api/pg/tables/users/data?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -1401,14 +1401,14 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 400 when database query param is missing", async () => {
-			const res = await app.request("/pg/tables/users/data");
+			const res = await app.request("/api/pg/tables/users/data");
 
 			expect(res.status).toBe(400);
 		});
 
 		it("should return 400 for invalid direction parameter", async () => {
 			const res = await app.request(
-				"/pg/tables/users/data?db=testdb&direction=invalid"
+				"/api/pg/tables/users/data?db=testdb&direction=invalid"
 			);
 
 			expect(res.status).toBe(400);
@@ -1416,7 +1416,7 @@ describe("Tables Routes", () => {
 
 		it("should return 400 for invalid order parameter", async () => {
 			const res = await app.request(
-				"/pg/tables/users/data?db=testdb&order=invalid"
+				"/api/pg/tables/users/data?db=testdb&order=invalid"
 			);
 
 			expect(res.status).toBe(400);
@@ -1426,7 +1426,7 @@ describe("Tables Routes", () => {
 			mockDao.getTableData.mockResolvedValue(mockDataResponse);
 
 			const res = await app.request(
-				"/pg/tables/users/data?db=testdb&filters=invalid-json"
+				"/api/pg/tables/users/data?db=testdb&filters=invalid-json"
 			);
 
 			expect(res.status).toBe(200);
@@ -1440,7 +1440,7 @@ describe("Tables Routes", () => {
 			mockDao.getTableData.mockResolvedValue(mockDataResponse);
 
 			const res = await app.request(
-				"/pg/tables/users/data?db=testdb&sort=invalid-json"
+				"/api/pg/tables/users/data?db=testdb&sort=invalid-json"
 			);
 
 			expect(res.status).toBe(200);
@@ -1455,7 +1455,7 @@ describe("Tables Routes", () => {
 				new Error("connect ECONNREFUSED")
 			);
 
-			const res = await app.request("/pg/tables/users/data?db=testdb");
+			const res = await app.request("/api/pg/tables/users/data?db=testdb");
 
 			expect(res.status).toBe(503);
 		});
@@ -1465,7 +1465,7 @@ describe("Tables Routes", () => {
 				new Error("Unexpected error")
 			);
 
-			const res = await app.request("/pg/tables/users/data?db=testdb");
+			const res = await app.request("/api/pg/tables/users/data?db=testdb");
 
 			expect(res.status).toBe(500);
 		});
@@ -1476,7 +1476,7 @@ describe("Tables Routes", () => {
 	// ============================================
 	describe("Invalid database type validation", () => {
 		it("should return 400 for invalid database type", async () => {
-			const res = await app.request("/invalid/tables?db=testdb");
+			const res = await app.request("/api/invalid/tables?db=testdb");
 
 			expect(res.status).toBe(400);
 		});
@@ -1484,20 +1484,20 @@ describe("Tables Routes", () => {
 		it("should accept mysql database type as valid", async () => {
 			mockDao.getTablesList.mockResolvedValue([]);
 
-			const res = await app.request("/mysql/tables?db=testdb");
+			const res = await app.request("/api/mysql/tables?db=testdb");
 
 			// mysql is a valid database type — route should succeed
 			expect([200, 500]).toContain(res.status);
 		});
 
 		it("should return 400 for sqlite database type (not supported)", async () => {
-			const res = await app.request("/sqlite/tables?db=testdb");
+			const res = await app.request("/api/sqlite/tables?db=testdb");
 
 			expect(res.status).toBe(400);
 		});
 
 		it("should return 400 for numeric database type", async () => {
-			const res = await app.request("/123/tables?db=testdb");
+			const res = await app.request("/api/123/tables?db=testdb");
 
 			expect(res.status).toBe(400);
 		});
@@ -1505,7 +1505,7 @@ describe("Tables Routes", () => {
 		it("should accept valid pg database type", async () => {
 			mockDao.getTablesList.mockResolvedValue([]);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			// This should fail because getTablesList throws when no tables exist
 			// but the route itself should be valid
@@ -1518,7 +1518,7 @@ describe("Tables Routes", () => {
 	// ============================================
 	describe("HTTP methods validation", () => {
 		it("should return 404 for PUT /tables", async () => {
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "PUT",
 			});
 
@@ -1526,7 +1526,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 404 for DELETE /tables (without column path)", async () => {
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "DELETE",
 			});
 
@@ -1534,7 +1534,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 404 for PATCH /tables", async () => {
-			const res = await app.request("/pg/tables?db=testdb", {
+			const res = await app.request("/api/pg/tables?db=testdb", {
 				method: "PATCH",
 			});
 
@@ -1542,7 +1542,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 404 for PUT /tables/:tableName/columns", async () => {
-			const res = await app.request("/pg/tables/users/columns?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/columns?db=testdb", {
 				method: "PUT",
 			});
 
@@ -1550,7 +1550,7 @@ describe("Tables Routes", () => {
 		});
 
 		it("should return 404 for PUT /tables/:tableName/data", async () => {
-			const res = await app.request("/pg/tables/users/data?db=testdb", {
+			const res = await app.request("/api/pg/tables/users/data?db=testdb", {
 				method: "PUT",
 			});
 
@@ -1567,7 +1567,7 @@ describe("Tables Routes", () => {
 				{ tableName: "test", rowCount: 0 },
 			]);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
 		});
@@ -1577,7 +1577,7 @@ describe("Tables Routes", () => {
 				{ tableName: "test", rowCount: 0 },
 			]);
 
-			const res = await app.request("/pg/tables?db=testdb");
+			const res = await app.request("/api/pg/tables?db=testdb");
 
 			expect(res.headers.get("Content-Type")).toContain("application/json");
 		});
@@ -1593,7 +1593,7 @@ describe("Tables Routes", () => {
 			]);
 
 			const requests = Array.from({ length: 10 }, () =>
-				app.request("/pg/tables?db=testdb")
+				app.request("/api/pg/tables?db=testdb")
 			);
 
 			const responses = await Promise.all(requests);
@@ -1623,9 +1623,9 @@ describe("Tables Routes", () => {
 			});
 
 			const [res1, res2, res3] = await Promise.all([
-				app.request("/pg/tables?db=testdb"),
-				app.request("/pg/tables/users/columns?db=testdb"),
-				app.request("/pg/tables/users/data?db=testdb"),
+				app.request("/api/pg/tables?db=testdb"),
+				app.request("/api/pg/tables/users/columns?db=testdb"),
+				app.request("/api/pg/tables/users/data?db=testdb"),
 			]);
 
 			expect(res1.status).toBe(200);
@@ -1642,7 +1642,7 @@ describe("Tables Routes", () => {
 			mockDao.getTableColumns.mockResolvedValue([]);
 
 			const res = await app.request(
-				"/pg/tables/user_profiles/columns?db=testdb"
+				"/api/pg/tables/user_profiles/columns?db=testdb"
 			);
 
 			expect(mockDao.getTableColumns).toHaveBeenCalledWith({
@@ -1657,21 +1657,21 @@ describe("Tables Routes", () => {
 			]);
 
 			const res = await app.request(
-				"/pg/tables?db=testdb&foo=bar&baz=123"
+				"/api/pg/tables?db=testdb&foo=bar&baz=123"
 			);
 
 			expect(res.status).toBe(200);
 		});
 
 		it("should return 404 for non-existent sub-routes", async () => {
-			const res = await app.request("/pg/tables/users/nonexistent?db=testdb");
+			const res = await app.request("/api/pg/tables/users/nonexistent?db=testdb");
 
 			expect(res.status).toBe(404);
 		});
 
 		it("should return 404 for deeply nested non-existent routes", async () => {
 			const res = await app.request(
-				"/pg/tables/users/columns/extra/path?db=testdb"
+				"/api/pg/tables/users/columns/extra/path?db=testdb"
 			);
 
 			expect(res.status).toBe(404);
@@ -1682,7 +1682,7 @@ describe("Tables Routes", () => {
 			mockDao.getTableColumns.mockResolvedValue([]);
 
 			const res = await app.request(
-				`/pg/tables/${longTableName}/columns?db=testdb`
+				`/api/pg/tables/${longTableName}/columns?db=testdb`
 			);
 
 			expect(mockDao.getTableColumns).toHaveBeenCalledWith({
@@ -1695,7 +1695,7 @@ describe("Tables Routes", () => {
 			mockDao.getTableColumns.mockResolvedValue([]);
 
 			const res = await app.request(
-				"/pg/tables/user%5Fprofiles/columns?db=testdb"
+				"/api/pg/tables/user%5Fprofiles/columns?db=testdb"
 			);
 
 			expect(mockDao.getTableColumns).toHaveBeenCalledWith({
@@ -1732,7 +1732,7 @@ describe("Tables Routes", () => {
 				},
 			});
 
-			const res = await app.request("/pg/tables/users/data?db=testdb");
+			const res = await app.request("/api/pg/tables/users/data?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
@@ -1766,7 +1766,7 @@ describe("Tables Routes", () => {
 				},
 			});
 
-			const res = await app.request("/pg/tables/users/data?db=testdb");
+			const res = await app.request("/api/pg/tables/users/data?db=testdb");
 
 			expect(res.status).toBe(200);
 			const json = await res.json();

--- a/packages/server/tests/utils/create-server.test.ts
+++ b/packages/server/tests/utils/create-server.test.ts
@@ -80,8 +80,8 @@ describe("createServer", () => {
 
 		it("should create app with strict: false option", async () => {
 			// Test that trailing slashes are handled gracefully
-			const res1 = await server.app.request("/databases");
-			const res2 = await server.app.request("/databases/");
+			const res1 = await server.app.request("/api/databases");
+			const res2 = await server.app.request("/api/databases/");
 
 			// Both should work (or at least not throw 500)
 			expect([200, 404]).toContain(res1.status);
@@ -91,49 +91,49 @@ describe("createServer", () => {
 
 	describe("Database type validation middleware", () => {
 		it("should accept pg as valid database type", async () => {
-			const res = await server.app.request("/databases");
+			const res = await server.app.request("/api/databases");
 			expect(res.status).toBe(200);
 		});
 
 		it("should reject invalid database type with 400", async () => {
-			const res = await server.app.request("/invalid/databases");
+			const res = await server.app.request("/api/invalid/databases");
 			expect(res.status).toBe(400);
 		});
 
 		it("should accept mysql database type as valid (no /mysql/databases route → 404)", async () => {
-			const res = await server.app.request("/mysql/databases");
+			const res = await server.app.request("/api/mysql/databases");
 			// mysql is now a valid dbType; /mysql/databases has no handler → 404
 			expect(res.status).toBe(404);
 		});
 
 		it("should reject sqlite database type", async () => {
-			const res = await server.app.request("/sqlite/databases");
+			const res = await server.app.request("/api/sqlite/databases");
 			expect(res.status).toBe(400);
 		});
 
 		it("should accept mongodb database type as valid (no /mongodb/databases route → 404)", async () => {
-			const res = await server.app.request("/mongodb/databases");
+			const res = await server.app.request("/api/mongodb/databases");
 			// mongodb is now a valid dbType; /mongodb/databases has no handler → 404
 			expect(res.status).toBe(404);
 		});
 
 		it("should reject numeric database type", async () => {
-			const res = await server.app.request("/123/databases");
+			const res = await server.app.request("/api/123/databases");
 			expect(res.status).toBe(400);
 		});
 
 		it("should reject uppercase PG", async () => {
-			const res = await server.app.request("/PG/databases");
+			const res = await server.app.request("/api/PG/databases");
 			expect(res.status).toBe(400);
 		});
 
 		it("should reject mixed case Pg", async () => {
-			const res = await server.app.request("/Pg/databases");
+			const res = await server.app.request("/api/Pg/databases");
 			expect(res.status).toBe(400);
 		});
 
 		it("should return validation error for invalid type", async () => {
-			const res = await server.app.request("/invalid/databases");
+			const res = await server.app.request("/api/invalid/databases");
 			const json = await res.json();
 
 			// zValidator returns error in a different format
@@ -145,13 +145,13 @@ describe("createServer", () => {
 
 	describe("CORS middleware", () => {
 		it("should include Access-Control-Allow-Origin header", async () => {
-			const res = await server.app.request("/databases");
+			const res = await server.app.request("/api/databases");
 
 			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
 		});
 
 		it("should include Access-Control-Allow-Methods header", async () => {
-			const res = await server.app.request("/databases");
+			const res = await server.app.request("/api/databases");
 
 			const methods = res.headers.get("Access-Control-Allow-Methods");
 			expect(methods).toContain("GET");
@@ -162,13 +162,13 @@ describe("createServer", () => {
 		});
 
 		it("should include Access-Control-Allow-Headers header", async () => {
-			const res = await server.app.request("/databases");
+			const res = await server.app.request("/api/databases");
 
 			expect(res.headers.get("Access-Control-Allow-Headers")).toContain("Content-Type");
 		});
 
 		it("should handle OPTIONS preflight request", async () => {
-			const res = await server.app.request("/databases", {
+			const res = await server.app.request("/api/databases", {
 				method: "OPTIONS",
 			});
 
@@ -179,7 +179,7 @@ describe("createServer", () => {
 
 	describe("Pretty JSON middleware", () => {
 		it("should return JSON response", async () => {
-			const res = await server.app.request("/databases");
+			const res = await server.app.request("/api/databases");
 			const json = await res.json();
 
 			// Verify it's valid JSON with expected structure
@@ -191,24 +191,24 @@ describe("createServer", () => {
 	describe("Routes registration", () => {
 		describe("/databases routes", () => {
 			it("should register GET /databases", async () => {
-				const res = await server.app.request("/databases");
+				const res = await server.app.request("/api/databases");
 				expect(res.status).toBe(200);
 			});
 
 			it("should register GET /databases/current", async () => {
-				const res = await server.app.request("/databases/current");
+				const res = await server.app.request("/api/databases/current");
 				expect(res.status).toBe(200);
 			});
 
 			it("should register GET /databases/connection", async () => {
-				const res = await server.app.request("/databases/connection");
+				const res = await server.app.request("/api/databases/connection");
 				expect(res.status).toBe(200);
 			});
 		});
 
 		describe("/tables routes", () => {
 			it("should register /tables route group", async () => {
-				const res = await server.app.request("/pg/tables");
+				const res = await server.app.request("/api/pg/tables");
 				// Should not be 404 (route exists), but may require params
 				expect([200, 400, 404, 500]).toContain(res.status);
 			});
@@ -216,7 +216,7 @@ describe("createServer", () => {
 
 		describe("/records routes", () => {
 			it("should register /records route group", async () => {
-				const res = await server.app.request("/pg/records");
+				const res = await server.app.request("/api/pg/records");
 				// Should not be 404 (route exists), but may require params
 				expect([200, 400, 404, 500]).toContain(res.status);
 			});
@@ -224,7 +224,7 @@ describe("createServer", () => {
 
 		describe("/query routes", () => {
 			it("should register /query route group", async () => {
-				const res = await server.app.request("/pg/query", { method: "POST" });
+				const res = await server.app.request("/api/pg/query", { method: "POST" });
 				// Should not be 404 (route exists), but may require body
 				expect([200, 400, 404, 500]).toContain(res.status);
 			});
@@ -232,7 +232,7 @@ describe("createServer", () => {
 
 		describe("/chat routes", () => {
 			it("should register /chat route group", async () => {
-				const res = await server.app.request("/pg/chat", { method: "POST" });
+				const res = await server.app.request("/api/pg/chat", { method: "POST" });
 				// Should not be 404 (route exists), but may require body
 				expect([200, 400, 404, 500]).toContain(res.status);
 			});
@@ -243,7 +243,7 @@ describe("createServer", () => {
 		it("should handle errors with custom error handler", async () => {
 			// The error handler is tested more thoroughly in error-handler.test.ts
 			// Here we just verify it's wired up correctly
-			const res = await server.app.request("/invalid/databases");
+			const res = await server.app.request("/api/invalid/databases");
 
 			expect(res.status).toBe(400);
 			const json = await res.json();
@@ -252,34 +252,46 @@ describe("createServer", () => {
 	});
 
 	describe("Base path handling", () => {
-		it("should have /databases routes at root level", async () => {
-			// /databases routes are now at root level (no dbType required)
-			const res = await server.app.request("/databases");
+		it("should have /databases routes under the API prefix (no dbType required)", async () => {
+			const res = await server.app.request("/api/databases");
 			expect(res.status).toBe(200);
 		});
 
 		it("should require valid database type for dbType-specific routes", async () => {
 			// Request with invalid dbType gets validated and fails
-			const res = await server.app.request("/invalid/tables?db=testdb");
+			const res = await server.app.request("/api/invalid/tables?db=testdb");
 			expect(res.status).toBe(400);
 		});
 
 		it("should return 404 for root path", async () => {
 			const res = await server.app.request("/");
-			// Root path doesn't match any registered routes
+			// Root path is owned by the SPA (served only outside test env), so in
+			// tests it matches no registered API route.
 			expect(res.status).toBe(404);
+		});
+
+		it("should not treat SPA client routes as a database type (db-studio#214)", async () => {
+			// A browser refresh on a client route like /table/:name must NOT be
+			// interpreted as a /:dbType API request. Pre-fix this returned 400
+			// "Invalid database type: table"; now it falls through to the SPA.
+			const res = await server.app.request("/table/users", {
+				headers: { Accept: "text/html" },
+			});
+			expect(res.status).not.toBe(400);
+			const body = await res.text();
+			expect(body).not.toContain("Invalid database type");
 		});
 	});
 
 	describe("Response format", () => {
 		it("should return JSON responses", async () => {
-			const res = await server.app.request("/databases");
+			const res = await server.app.request("/api/databases");
 
 			expect(res.headers.get("Content-Type")).toContain("application/json");
 		});
 
 		it("should wrap data in data property", async () => {
-			const res = await server.app.request("/databases");
+			const res = await server.app.request("/api/databases");
 			const json = await res.json();
 
 			expect(json).toHaveProperty("data");
@@ -299,8 +311,8 @@ describe("createServer", () => {
 			const server2 = createServer();
 
 			const [res1, res2] = await Promise.all([
-				server1.app.request("/databases"),
-				server2.app.request("/databases"),
+				server1.app.request("/api/databases"),
+				server2.app.request("/api/databases"),
 			]);
 
 			expect(res1.status).toBe(200);
@@ -310,30 +322,30 @@ describe("createServer", () => {
 
 	describe("Query parameters handling", () => {
 		it("should ignore unknown query parameters", async () => {
-			const res = await server.app.request("/databases?unknown=value&foo=bar");
+			const res = await server.app.request("/api/databases?unknown=value&foo=bar");
 			expect(res.status).toBe(200);
 		});
 
 		it("should handle empty query string", async () => {
-			const res = await server.app.request("/databases?");
+			const res = await server.app.request("/api/databases?");
 			expect(res.status).toBe(200);
 		});
 	});
 
 	describe("Path handling edge cases", () => {
 		it("should handle double slashes", async () => {
-			const res = await server.app.request("/pg//databases");
+			const res = await server.app.request("/api/pg//databases");
 			// May normalize or return 404
 			expect([200, 404]).toContain(res.status);
 		});
 
 		it("should return 404 for unknown routes under valid dbType", async () => {
-			const res = await server.app.request("/pg/unknown-route");
+			const res = await server.app.request("/api/pg/unknown-route");
 			expect(res.status).toBe(404);
 		});
 
 		it("should return 404 for deeply nested unknown routes", async () => {
-			const res = await server.app.request("/pg/unknown/deep/path");
+			const res = await server.app.request("/api/pg/unknown/deep/path");
 			expect(res.status).toBe(404);
 		});
 	});

--- a/packages/shared/src/constants/defaults.ts
+++ b/packages/shared/src/constants/defaults.ts
@@ -16,6 +16,13 @@ export const DEFAULTS = {
 	ENV: ".env",
 	VAR_NAME: "DATABASE_URL",
 	BASE_URL: "https://api.dbstudio.localhost",
+	/**
+	 * URL namespace for all HTTP API routes. The API and the SPA are served
+	 * from the same origin in self-hosted mode, so the API is mounted under
+	 * this prefix to keep it from colliding with client-side (SPA) routes such
+	 * as `/table/:name` on a page refresh. See db-studio#214.
+	 */
+	API_PREFIX: "/api",
 	IS_DEV: nodeEnv === "development",
 	PROXY_URL:
 		env?.DB_STUDIO_PROXY_URL ??

--- a/packages/web/src/components/chat/chat-sidebar.tsx
+++ b/packages/web/src/components/chat/chat-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CHAT_SUGGESTIONS } from "@db-studio/shared/constants";
+import { CHAT_SUGGESTIONS, DEFAULTS } from "@db-studio/shared/constants";
 import { Button } from "@db-studio/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@db-studio/ui/tooltip";
 import { fetchServerSentEvents, useChat } from "@tanstack/ai-react";
@@ -63,7 +63,7 @@ const ChatSidebarContent = ({
 	const { remaining } = rateLimit ?? { remaining: 0, limit: 0 };
 
 	const { messages, sendMessage, isLoading, clear, stop } = useChat({
-		connection: fetchServerSentEvents(`${getBaseUrl()}/chat`),
+		connection: fetchServerSentEvents(`${getBaseUrl()}${DEFAULTS.API_PREFIX}/chat`),
 		body: { db },
 		onError: (error) => console.error("Error:", error.message),
 		onFinish: () => {

--- a/packages/web/src/shared/api/client.ts
+++ b/packages/web/src/shared/api/client.ts
@@ -88,7 +88,9 @@ export class ApiClient {
 
 	constructor(resolveBaseUrl: () => string = getBaseUrl) {
 		this.resolveBaseUrl = resolveBaseUrl;
-		const baseURL = this.resolveBaseUrl();
+		// API is namespaced under API_PREFIX so it never collides with SPA
+		// routes served from the same origin. See db-studio#214.
+		const baseURL = `${this.resolveBaseUrl()}${DEFAULTS.API_PREFIX}`;
 		this.rootApi = setupInterceptors(axios.create({ baseURL }));
 		this.api = setupInterceptors(axios.create({ baseURL }));
 	}
@@ -97,7 +99,7 @@ export class ApiClient {
 		if (this.dbType === type) return;
 
 		this.dbType = type;
-		this.api.defaults.baseURL = `${this.resolveBaseUrl()}/${type}`;
+		this.api.defaults.baseURL = `${this.resolveBaseUrl()}${DEFAULTS.API_PREFIX}/${type}`;
 	}
 
 	getDbType(): DatabaseTypeSchema | null {

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -114,7 +114,8 @@ export default defineConfig(({ mode }) => {
         target: process.env.VITE_API_PROXY_TARGET ?? 'https://api.dbstudio.localhost',
         changeOrigin: true,
         secure: false,
-        rewrite: (path) => path.replace(/^\/api/, ""),
+        // No rewrite: the server owns the /api namespace, so forward the
+        // prefix intact instead of stripping it. See db-studio#214.
       },
     },
   },


### PR DESCRIPTION
## Summary

- **Root cause — SPA/API namespace collision on one origin.** The server serves the SPA and the HTTP API from the same origin. API routes lived at the root namespace (`/:dbType/*` plus `/databases`, `/chat`), and the `index.html` fallback sat *after* the `/:dbType/*` validator. So a browser refresh on a client route like `/table/:name` was matched by the dbType validator, `table` failed validation, and the server returned `400 {"error":"Invalid database type: \"table\""}` instead of loading the app. Every top-level client route (`/table`, `/schema`, `/runner`, `/logs`) hit this on refresh / open-in-new-tab.
- **Fix — namespace the whole API under `/api`.** All API routes now mount under a shared `API_PREFIX` (`/api`): databases, chat, and the dbType-scoped tables/records/query routers. The SPA now owns the root namespace, so the `/*` fallback serves `index.html` for every non-API path — deep-link refreshes work. The API is internal-only (no external/documented consumers), so this is not a breaking change.
- **Client wiring.** The web axios client (`rootApi` + per-dbType `api`) and the chat SSE stream now target `${origin}/api`, sourced from the single shared `DEFAULTS.API_PREFIX` constant so the three call sites can't drift.
- **API 404s stay JSON.** Unmatched `/api/*` paths now return a JSON 404 instead of falling through to the SPA's HTML, so API clients never receive `index.html` by mistake.
- **Dev proxy.** Dropped the vite dev proxy's `/api` strip-rewrite — the server now owns the `/api` namespace, so the prefix is forwarded intact.
- **Tests.** Prefixed the server route + `.http` fixture tests with `/api`, and added a regression test asserting a client-route refresh (`GET /table/users`) is no longer treated as a database type. (`error-handler.test.ts` builds its own local Hono app and was intentionally left unprefixed.)

## Testing

1. `cd packages/server && bun run test` → **997 passed** (incl. the new `db-studio#214` regression test).
2. `bun run typecheck` (web + ui + shared) → clean. Server type profile is unchanged vs `stage` (the one pre-existing `create-server` inference error is unrelated debt; the server builds via tsup and has no typecheck gate).
3. `bun run build` → 6/6 packages succeed. `biome check` on changed files → clean.
4. Manual: build + run self-hosted, open a table, hit refresh / open the URL in a new tab → app loads instead of the JSON error.

Closes #214

---

## Glossary

| Term | Definition |
|------|------------|
| SPA fallback | A catch-all route that serves the client app's `index.html` for any unmatched path, so client-side (in-browser) routing can take over after a hard page load / refresh. |
| Client route | A URL owned by the front-end router (TanStack Router) — e.g. `/table/:name` — that has no matching server endpoint; it only means something once `index.html` + JS load. |
| `/:dbType/*` | A server route pattern where the first path segment is the database type (`pg`, `mysql`, …), validated against the adapter registry. `table` is not a valid type, hence the original 400. |
| `API_PREFIX` | Shared constant (`/api`) that namespaces every HTTP API route, keeping the API and SPA from colliding on the same origin. |
| SSE | Server-Sent Events — the one-way streaming transport the AI chat uses; its URL is built directly (not via axios), so it needed the `/api` prefix applied separately. |
| Origin | Scheme + host + port. In self-hosted mode the SPA and API share one origin, which is why the namespaces overlapped. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API requests are now served under a dedicated `/api` path to reduce clashes with app pages.
  * Chat SSE and database API calls automatically use the new API base path.

* **Bug Fixes**
  * Unmatched API routes now return clearer JSON `404` responses under the `/api` namespace.
  * Static assets and client-side app pages continue to load correctly alongside API routes.

* **Tests / Documentation**
  * Updated API route coverage to reflect the new `/api` base path.
  * Added a public glossary/architecture document (`CONTEXT.md`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->