### PR TITLE
fix(#229): stop logging request data and harden AI-proxy rate-limit keying

### DIFF
--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -37,10 +37,6 @@ app.post("/chat", async (c) => {
 			return c.json({ error: "Invalid request: messages array required" }, 400);
 		}
 
-		console.log("messages", messages);
-		console.log("systemPrompt", systemPrompt);
-		console.log("conversationId", conversationId);
-
 		const stream = chat({
 			adapter: createGeminiChat("gemini-3-flash-preview", env.GEMINI_API_KEY, {
 				temperature: 0.1, // Very low - we want deterministic, accurate SQL

--- a/packages/proxy/src/limit.ts
+++ b/packages/proxy/src/limit.ts
@@ -8,9 +8,8 @@ export const keyGenerator = (c: Context) => {
 	const cfConnectingIp = c.req.header("cf-connecting-ip");
 	const xRealIp = c.req.header("x-real-ip");
 	const xForwardedFor = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
-	const apiKey = c.req.header("x-api-key");
 
-	const identifier = apiKey ?? cfConnectingIp ?? xRealIp ?? xForwardedFor ?? "anonymous";
+	const identifier = cfConnectingIp ?? xRealIp ?? xForwardedFor ?? "anonymous";
 	return identifier;
 };
 


### PR DESCRIPTION
## Summary
- **Removed request-payload logging from the `/chat` proxy handler** — the handler wrote the full `messages`, `systemPrompt`, and `conversationId` to the Worker console on every call; `systemPrompt` carries the connected database's schema, so this kept user schema/PII in Cloudflare Workers logs with no benefit. Now nothing about the request body is logged.
- **Rate limiter now keys only on Cloudflare-trusted request attributes** — the limit key previously preferred a client-supplied `x-api-key` header that the proxy never validates, so the per-key daily cap could be sidestepped by varying that header (each value is a fresh bucket). The key now derives from `cf-connecting-ip` (edge-set, unspoofable) with the same fallbacks, so the cap actually holds.

## Testing
1. `bun run typecheck` → passes
2. `bun run format` → passes
3. `bun run build` → passes
(The proxy package has no test suite; verified by typecheck + build + grep that the log lines and header reference are gone.)

Closes #229

## Glossary
| Term | Definition |
|------|------------|
| `cf-connecting-ip` | Originating client IP header set by Cloudflare's edge; cannot be forged by the client. |
| `systemPrompt` | The instruction/context payload sent to the model; here it embeds the connected database schema. |
| Rate-limit key | The identifier the limiter buckets requests under; if attacker-controllable, the limit is bypassable. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary debug logging from chat requests, reducing noise and keeping request handling cleaner.
  * Improved proxy rate-limiting identity detection by using client IP information instead of API key headers, making limits more consistent across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->