### PR TITLE
fix(#231): consolidate CORS to a single same-origin-default policy

### DIFF
--- a/packages/server/src/utils/create-server.ts
+++ b/packages/server/src/utils/create-server.ts
@@ -64,9 +64,26 @@ export const createServer = () => {
 
 	const app = new Hono<AppType>({ strict: false })
 		/**
-		 * Enable CORS
+		 * Enable CORS.
+		 *
+		 * Same-origin by default: the SPA is served from the same origin as the
+		 * API, so no cross-origin access is needed. An empty allowlist means no
+		 * allow-origin header is emitted for cross-origin requests, which
+		 * prevents drive-by-localhost attacks (any other browser tab issuing
+		 * cross-origin reads/edits/drops against the user's DB).
+		 *
+		 * Deployments that genuinely need cross-origin access (e.g. a hosted
+		 * fork serving the SPA from a different origin) set `ALLOWED_ORIGINS` to
+		 * a comma-separated list of explicit origins. Never `*`.
 		 */
-		.use("/*", cors())
+		.use(
+			"/*",
+			cors({
+				origin: process.env.ALLOWED_ORIGINS?.split(",").map((o) => o.trim()) ?? [],
+				allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+				allowHeaders: ["Content-Type"],
+			}),
+		)
 
 		/**
 		 * Pretty print the JSON response
@@ -87,16 +104,6 @@ export const createServer = () => {
 				path: path.resolve(getWebDistPath(), "favicon.ico"),
 			}),
 		)
-
-		/**
-		 * Handle CORS requests
-		 */
-		.use("*", async (c, next) => {
-			c.header("Access-Control-Allow-Origin", "*");
-			c.header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-			c.header("Access-Control-Allow-Headers", "Content-Type");
-			await next();
-		})
 
 		/**
 		 * Handle errors

--- a/packages/server/tests/routes/databases.routes.test.ts
+++ b/packages/server/tests/routes/databases.routes.test.ts
@@ -504,7 +504,7 @@ describe("Databases Routes", () => {
 
 			const res = await app.request("/api/databases");
 
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 		});
 
 		it("should return JSON content type", async () => {

--- a/packages/server/tests/routes/mongodb/databases.routes.mongodb.test.ts
+++ b/packages/server/tests/routes/mongodb/databases.routes.mongodb.test.ts
@@ -287,7 +287,7 @@ describe("Databases Routes (MongoDB)", () => {
 
 			const res = await app.request("/api/databases");
 
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 		});
 
 		it("returns JSON content type", async () => {

--- a/packages/server/tests/routes/mssql/databases.routes.mssql.test.ts
+++ b/packages/server/tests/routes/mssql/databases.routes.mssql.test.ts
@@ -147,7 +147,7 @@ describe("Databases Routes (MSSQL)", () => {
 			mockDao.getDatabasesList.mockResolvedValue([]);
 			const res = await app.request("/api/databases");
 
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 			expect(res.headers.get("Content-Type")).toContain("application/json");
 		});
 	});

--- a/packages/server/tests/routes/mssql/tables.routes.mssql.test.ts
+++ b/packages/server/tests/routes/mssql/tables.routes.mssql.test.ts
@@ -251,7 +251,7 @@ describe("Tables Routes (MSSQL)", () => {
 			mockDao.getTablesList.mockResolvedValue([]);
 			const res = await app.request("/api/mssql/tables?db=testdb");
 
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 			expect(res.headers.get("Content-Type")).toContain("application/json");
 		});
 

--- a/packages/server/tests/routes/mysql/databases.routes.mysql.test.ts
+++ b/packages/server/tests/routes/mysql/databases.routes.mysql.test.ts
@@ -354,7 +354,7 @@ describe("Databases Routes (MySQL)", () => {
 
 			const res = await app.request("/api/databases");
 
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 		});
 
 		it("should return JSON content type", async () => {

--- a/packages/server/tests/routes/mysql/query.routes.mysql.test.ts
+++ b/packages/server/tests/routes/mysql/query.routes.mysql.test.ts
@@ -453,7 +453,7 @@ describe("Query Routes (MySQL)", () => {
 				body: JSON.stringify({ query: "SELECT 1" }),
 			});
 
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 		});
 
 		it("should return JSON content type", async () => {

--- a/packages/server/tests/routes/mysql/records.routes.mysql.test.ts
+++ b/packages/server/tests/routes/mysql/records.routes.mysql.test.ts
@@ -708,7 +708,7 @@ describe("Records Routes (MySQL)", () => {
 				body: JSON.stringify({ tableName: "users", data: { name: "Test" } }),
 			});
 
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 		});
 
 		it("should return JSON content type", async () => {

--- a/packages/server/tests/routes/mysql/tables.routes.mysql.test.ts
+++ b/packages/server/tests/routes/mysql/tables.routes.mysql.test.ts
@@ -927,7 +927,7 @@ describe("Tables Routes (MySQL)", () => {
 			mockDao.getTablesList.mockResolvedValue([{ tableName: "test", rowCount: 0 }]);
 
 			const res = await app.request("/api/mysql/tables?db=testdb");
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 		});
 
 		it("should return JSON content type", async () => {

--- a/packages/server/tests/routes/query.routes.test.ts
+++ b/packages/server/tests/routes/query.routes.test.ts
@@ -734,7 +734,7 @@ describe("Query Routes", () => {
 				body: JSON.stringify({ query: "SELECT 1 as id" }),
 			});
 
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 		});
 
 		it("should return JSON content type", async () => {

--- a/packages/server/tests/routes/records.routes.test.ts
+++ b/packages/server/tests/routes/records.routes.test.ts
@@ -1258,7 +1258,7 @@ describe("Records Routes", () => {
 				}),
 			});
 
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 		});
 
 		it("should return JSON content type", async () => {

--- a/packages/server/tests/routes/tables.routes.test.ts
+++ b/packages/server/tests/routes/tables.routes.test.ts
@@ -1569,7 +1569,7 @@ describe("Tables Routes", () => {
 
 			const res = await app.request("/api/pg/tables?db=testdb");
 
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 		});
 
 		it("should return JSON content type", async () => {

--- a/packages/server/tests/utils/create-server.test.ts
+++ b/packages/server/tests/utils/create-server.test.ts
@@ -144,14 +144,25 @@ describe("createServer", () => {
 	});
 
 	describe("CORS middleware", () => {
-		it("should include Access-Control-Allow-Origin header", async () => {
+		it("should NOT emit a wildcard Access-Control-Allow-Origin for a same-origin/no-origin request", async () => {
 			const res = await server.app.request("/api/databases");
 
-			expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			// Same-origin default: no allowlist configured means no allow-origin
+			// header is reflected. A cross-origin caller therefore gets no CORS
+			// grant (prevents drive-by-localhost).
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
 		});
 
-		it("should include Access-Control-Allow-Methods header", async () => {
-			const res = await server.app.request("/api/databases");
+		it("should NOT emit an Access-Control-Allow-Origin for a disallowed cross-origin request", async () => {
+			const res = await server.app.request("/api/databases", {
+				headers: { Origin: "https://evil.example" },
+			});
+
+			expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+		});
+
+		it("should advertise allowed methods on a CORS preflight", async () => {
+			const res = await server.app.request("/api/databases", { method: "OPTIONS" });
 
 			const methods = res.headers.get("Access-Control-Allow-Methods");
 			expect(methods).toContain("GET");
@@ -161,8 +172,8 @@ describe("createServer", () => {
 			expect(methods).toContain("OPTIONS");
 		});
 
-		it("should include Access-Control-Allow-Headers header", async () => {
-			const res = await server.app.request("/api/databases");
+		it("should advertise allowed headers on a CORS preflight", async () => {
+			const res = await server.app.request("/api/databases", { method: "OPTIONS" });
 
 			expect(res.headers.get("Access-Control-Allow-Headers")).toContain("Content-Type");
 		});


### PR DESCRIPTION
## Summary
- **Collapsed two overlapping CORS mechanisms into one** — the server called Hono's `cors()` and then a second middleware that hard-set `Access-Control-Allow-Origin: *` on every response. Two mechanisms is a correctness hazard and the wildcard grants cross-origin access the app never needs (the SPA is served same-origin as the API).
- **Default is now same-origin; cross-origin is opt-in via `ALLOWED_ORIGINS`** — with no allowlist configured, no allow-origin header is emitted for cross-origin requests. Deployments serving the SPA from a different origin set `ALLOWED_ORIGINS` to an explicit comma-separated list (never `*`).
- **Updated CORS test assertions to the new policy** — 12 server test files asserted the old wildcard; they now assert no allow-origin for a disallowed/no-origin request, plus new preflight (OPTIONS) coverage and a disallowed-cross-origin case.

## Testing
1. `cd packages/server && bun run test` → 998 tests pass
2. `bun run typecheck`, `bun run format`, `bun run build` → pass

Closes #231

## Glossary
| Term | Definition |
|------|------------|
| CORS | Browser mechanism controlling which origins may read cross-origin responses. |
| Same-origin default | Emitting no allow-origin header so only the same-origin page can call the API. |
| `ALLOWED_ORIGINS` | New env var: comma-separated explicit origins permitted cross-origin access. |