### PR TITLE
refactor(#232): remove the legacy src/lib/api.ts facade

### DIFF
--- a/docs/FRONTEND_ARCHITECTURE_PLAN.md
+++ b/docs/FRONTEND_ARCHITECTURE_PLAN.md
@@ -103,7 +103,7 @@ boundaries exist.
 
 ### Phase 6 — Cleanup & Hardening
 
-- [ ] Delete the legacy `src/lib/api.ts` compatibility facade once all imports use `src/shared/api`
+- [x] Delete the legacy `src/lib/api.ts` compatibility facade once all imports use `src/shared/api`
 - [ ] Collapse copied endpoint logic into the shared API modules and remove duplicate request construction
 - [ ] Audit query invalidation keys and replace ad hoc cache-key arrays with query-key factories
 - [ ] Add tests around `ApiClient`, query-key factories, and table-model behavior

--- a/packages/web/src/features/tables/components/fk-drawer-content.tsx
+++ b/packages/web/src/features/tables/components/fk-drawer-content.tsx
@@ -13,7 +13,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { ExternalLink } from "lucide-react";
 import { useMemo } from "react";
 import { useTableCols } from "@/features/schema";
-import { api } from "@/lib/api";
+import { api } from "@/shared/api/client";
 import { useDatabaseStore } from "@/stores/database.store";
 import type { TableRecord } from "@/types/table.type";
 import { CellCopyButton } from "./cell-copy-button";

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1,9 +1,0 @@
-export {
-	ApiClient,
-	api,
-	apiClient,
-	getBaseUrl,
-	getDbType,
-	rootApi,
-	setDbType,
-} from "@/shared/api/client";


### PR DESCRIPTION
## Summary
- **Repointed the last `@/lib/api` importer to the canonical `@/shared/api/client`** — `fk-drawer-content.tsx` was the only remaining consumer of the legacy compatibility facade.
- **Deleted `src/lib/api.ts` and checked off Phase 6** — the facade was a pure re-export barrel; with no importers left it is removed, and the corresponding checkbox in `docs/FRONTEND_ARCHITECTURE_PLAN.md` is now checked. `src/shared/api/` is the sole API import surface (per `AGENTS.md`).

## Testing
1. `bun run typecheck` → passes (a dangling import would fail here)
2. `bun run format` → passes
3. `bun run build` → passes
4. `grep -rn "@/lib/api" packages/web/src` → no matches

Closes #232

## Glossary
| Term | Definition |
|------|------------|
| Facade / re-export barrel | A module that only re-exports another module's symbols to preserve an old import path during a migration. |
| `@/shared/api` | The canonical client-API layer in the web package (transport wrappers over Axios). |