### PR TITLE
fix(server): allow local dev origins in cors and add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,7 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/dbstudio"
 # NODE_ENV=development
 
 # Comma-separated list of allowed CORS origins.
-# In development (NODE_ENV=development), localhost / *.localhost origins are permitted automatically.
+# In development (NODE_ENV=development), localhost, *.localhost, and 127.0.0.1 origins are permitted automatically.
 # ALLOWED_ORIGINS="https://web.db-studio.localhost,http://localhost:3000,http://localhost:3001"
 
 # Public URL of the db-studio server (used for CLI logs and automatic browser opening)

--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,8 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/dbstudio"
 
 # Comma-separated list of allowed CORS origins.
 # In development (NODE_ENV=development), localhost, *.localhost, and 127.0.0.1 origins are permitted automatically.
-# ALLOWED_ORIGINS="https://web.db-studio.localhost,http://localhost:3000,http://localhost:3001"
+# Required when accessing via custom Portless ports (e.g. :1355) to prevent "Failed to connect to the database" / CORS errors:
+ALLOWED_ORIGINS=https://web.db-studio.localhost:1355,https://web.db-studio.localhost
 
 # Public URL of the db-studio server (used for CLI logs and automatic browser opening)
 # DB_STUDIO_SERVER_URL="https://api.db-studio.localhost"

--- a/.env.example
+++ b/.env.example
@@ -44,10 +44,12 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/dbstudio"
 # Node environment: development | production | test
 # NODE_ENV=development
 
-# Comma-separated list of allowed CORS origins.
-# In development (NODE_ENV=development), localhost, *.localhost, and 127.0.0.1 origins are permitted automatically.
-# Required when accessing via custom Portless ports (e.g. :1355) to prevent "Failed to connect to the database" / CORS errors:
-ALLOWED_ORIGINS=https://web.db-studio.localhost:1355,https://web.db-studio.localhost
+# Explicit cross-origin deployment override (comma-separated list of allowed CORS origins).
+# Not needed for local development: when NODE_ENV=development, localhost,
+# *.localhost, and 127.0.0.1 origins are permitted automatically on any port
+# (including custom Portless ports such as :1355). Only set this to allow
+# additional origins, for example in non-development environments:
+# ALLOWED_ORIGINS=https://web.db-studio.localhost:1355,https://web.db-studio.localhost
 
 # Public URL of the db-studio server (used for CLI logs and automatic browser opening)
 # DB_STUDIO_SERVER_URL="https://api.db-studio.localhost"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,82 @@
+# ==============================================================================
+# db-studio Environment Configuration
+# Copy this file to .env and configure for your local environment:
+#   cp .env.example .env
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# 1. Database Connection (Required)
+# ------------------------------------------------------------------------------
+# Primary database connection string used by db-studio server and CLI.
+# Supported database types: PostgreSQL, MySQL, SQL Server (MSSQL), MongoDB, SQLite, Redis.
+#
+# Examples by database engine:
+#
+# PostgreSQL:
+#   DATABASE_URL="postgresql://postgres:postgres@localhost:5432/dbstudio"
+#
+# MySQL:
+#   DATABASE_URL="mysql://root@localhost:3306/dbstudio"
+#
+# SQL Server (MSSQL):
+#   DATABASE_URL="mssql://sa:DbStudio1!@localhost:1433/dbstudio"
+#
+# MongoDB:
+#   DATABASE_URL="mongodb://localhost:27017/dbstudio"
+#
+# SQLite (relative or absolute file path):
+#   DATABASE_URL="sqlite://./db/dbstudio.sqlite"
+#
+# Redis (database index 0..N):
+#   DATABASE_URL="redis://localhost:6379/0"
+
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/dbstudio"
+
+# ------------------------------------------------------------------------------
+# 2. Server Configuration (Optional)
+# ------------------------------------------------------------------------------
+# Port for the Hono API server (default: 3333, or dynamically assigned by Portless)
+# PORT=3333
+
+# Host to bind the API server to (default: 127.0.0.1 or 0.0.0.0)
+# HOST=127.0.0.1
+
+# Node environment: development | production | test
+# NODE_ENV=development
+
+# Comma-separated list of allowed CORS origins.
+# In development (NODE_ENV=development), localhost / *.localhost origins are permitted automatically.
+# ALLOWED_ORIGINS="https://web.db-studio.localhost,http://localhost:3000,http://localhost:3001"
+
+# Public URL of the db-studio server (used for CLI logs and automatic browser opening)
+# DB_STUDIO_SERVER_URL="https://api.db-studio.localhost"
+
+# URL of the AI proxy service (defaults to https://proxy.db-studio.localhost in dev,
+# or Cloudflare Workers proxy in production)
+# DB_STUDIO_PROXY_URL="https://proxy.db-studio.localhost"
+
+# ------------------------------------------------------------------------------
+# 3. AI Proxy / Assistant (packages/proxy - Optional)
+# ------------------------------------------------------------------------------
+# Google Gemini API key used by the proxy to power AI-assisted SQL query generation
+# GEMINI_API_KEY=""
+
+# Upstash Redis REST credentials for proxy rate-limiting
+# UPSTASH_REDIS_REST_URL=""
+# UPSTASH_REDIS_REST_TOKEN=""
+
+# ------------------------------------------------------------------------------
+# 4. Web Frontend (packages/web - Optional)
+# ------------------------------------------------------------------------------
+# Base API URL used by the web client in development (defaults to https://api.db-studio.localhost)
+# VITE_API_URL="https://api.db-studio.localhost"
+
+# Vite dev proxy target (defaults to https://api.db-studio.localhost)
+# VITE_API_PROXY_TARGET="https://api.db-studio.localhost"
+
+# Enable TanStack Router DevTools server bus ("true" or "false")
+# VITE_TANSTACK_SERVER_BUS="false"
+
+# Monitoring & analytics (optional)
+# VITE_SENTRY_DSN=""
+# VITE_POSTHOG_KEY=""

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -53,6 +53,15 @@ export const main = async () => {
 	// This ensures the db pool is initialized with the correct connection string
 	process.env.DATABASE_URL = DATABASE_URL;
 
+	// Populate other env variables from .env if not already set in process.env
+	if (ENV) {
+		for (const [key, value] of Object.entries(ENV)) {
+			if (process.env[key] === undefined) {
+				process.env[key] = value;
+			}
+		}
+	}
+
 	// Import database modules dynamically after setting DATABASE_URL.
 	const { checkDatabaseConnection, getDatabaseConnectionDetails } = await import(
 		"@/cmd/check-database.js"

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -33,10 +33,20 @@ export const main = async () => {
 
 	intro(color.inverse(" db-studio "));
 
+	const ENV = env ? await loadEnv(env) : await loadEnv();
+
+	// Populate other env variables from .env if not already set in process.env
+	if (ENV) {
+		for (const [key, value] of Object.entries(ENV)) {
+			if (process.env[key] === undefined) {
+				process.env[key] = value;
+			}
+		}
+	}
+
 	const PORT = Number.parseInt(port ?? process.env.PORT ?? String(DEFAULTS.PORT), 10);
 	const HOST = process.env.HOST;
 	const VAR_NAME = varName || DEFAULTS.VAR_NAME;
-	const ENV = env ? await loadEnv(env) : await loadEnv();
 	const hasEnvFileValue = Boolean(ENV?.[VAR_NAME]);
 	const hasProcessValue = Boolean(process.env[VAR_NAME]);
 	const DATABASE_URL = databaseUrl ? databaseUrl : await getDatabaseUrl(ENV, VAR_NAME);
@@ -52,15 +62,6 @@ export const main = async () => {
 	// Set DATABASE_URL in process.env before importing createServer
 	// This ensures the db pool is initialized with the correct connection string
 	process.env.DATABASE_URL = DATABASE_URL;
-
-	// Populate other env variables from .env if not already set in process.env
-	if (ENV) {
-		for (const [key, value] of Object.entries(ENV)) {
-			if (process.env[key] === undefined) {
-				process.env[key] = value;
-			}
-		}
-	}
 
 	// Import database modules dynamically after setting DATABASE_URL.
 	const { checkDatabaseConnection, getDatabaseConnectionDetails } = await import(
@@ -102,12 +103,14 @@ export const main = async () => {
 	outro(color.green("Ready"));
 };
 
-main().catch((error: unknown) => {
-	const message = error instanceof Error ? error.message : String(error);
-	const sanitizedMessage = message.replace(
-		/\b(?:postgres(?:ql)?|mysql2?|mssql|sqlserver|mongodb(?:\+srv)?|sqlite|rediss?):\/\/\S+/gi,
-		"the configured database",
-	);
-	outro(color.red(`Startup failed: ${sanitizedMessage}`));
-	process.exit(1);
-});
+if (process.env.NODE_ENV !== "test") {
+	main().catch((error: unknown) => {
+		const message = error instanceof Error ? error.message : String(error);
+		const sanitizedMessage = message.replace(
+			/\b(?:postgres(?:ql)?|mysql2?|mssql|sqlserver|mongodb(?:\+srv)?|sqlite|rediss?):\/\/\S+/gi,
+			"the configured database",
+		);
+		outro(color.red(`Startup failed: ${sanitizedMessage}`));
+		process.exit(1);
+	});
+}

--- a/packages/server/src/utils/create-server.ts
+++ b/packages/server/src/utils/create-server.ts
@@ -80,7 +80,27 @@ export const createServer = () => {
 		.use(
 			"/*",
 			cors({
-				origin: process.env.ALLOWED_ORIGINS?.split(",").map((o) => o.trim()) ?? [],
+				origin: (origin) => {
+					if (!origin) return undefined;
+					const allowed =
+						process.env.ALLOWED_ORIGINS?.split(",")
+							.map((o) => o.trim())
+							.filter(Boolean) ?? [];
+					if (allowed.includes(origin)) return origin;
+					if (process.env.NODE_ENV === "development") {
+						try {
+							const url = new URL(origin);
+							if (
+								url.hostname === "localhost" ||
+								url.hostname.endsWith(".localhost") ||
+								url.hostname === "127.0.0.1"
+							) {
+								return origin;
+							}
+						} catch {}
+					}
+					return undefined;
+				},
 				allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
 				allowHeaders: ["Content-Type"],
 			}),

--- a/packages/server/tests/cmd/main.test.ts
+++ b/packages/server/tests/cmd/main.test.ts
@@ -1,0 +1,167 @@
+import { DEFAULTS } from "@db-studio/shared/constants";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	args: vi.fn(),
+	loadEnv: vi.fn(),
+	getDatabaseUrl: vi.fn(),
+	checkDatabaseConnection: vi.fn(),
+	getDatabaseConnectionDetails: vi.fn(),
+	openBrowser: vi.fn(),
+	shouldOpenBrowser: vi.fn(),
+	createServer: vi.fn(),
+	serve: vi.fn(),
+	intro: vi.fn(),
+	outro: vi.fn(),
+	log: {
+		success: vi.fn(),
+		warn: vi.fn(),
+	},
+	spinner: vi.fn(() => ({
+		start: vi.fn(),
+		stop: vi.fn(),
+	})),
+}));
+
+vi.mock("@clack/prompts", () => ({
+	intro: mocks.intro,
+	outro: mocks.outro,
+	log: mocks.log,
+	spinner: mocks.spinner,
+}));
+
+vi.mock("@hono/node-server", () => ({
+	serve: mocks.serve,
+}));
+
+vi.mock("@/cmd/args.js", () => ({
+	args: mocks.args,
+}));
+
+vi.mock("@/cmd/load-env.js", () => ({
+	loadEnv: mocks.loadEnv,
+}));
+
+vi.mock("@/cmd/get-db-url.js", () => ({
+	getDatabaseUrl: mocks.getDatabaseUrl,
+}));
+
+vi.mock("@/cmd/check-database.js", () => ({
+	checkDatabaseConnection: mocks.checkDatabaseConnection,
+	getDatabaseConnectionDetails: mocks.getDatabaseConnectionDetails,
+}));
+
+vi.mock("@/cmd/open-browser.js", () => ({
+	openBrowser: mocks.openBrowser,
+	shouldOpenBrowser: mocks.shouldOpenBrowser,
+}));
+
+vi.mock("@/utils/create-server.js", () => ({
+	createServer: mocks.createServer,
+}));
+
+import { main } from "@/index.js";
+
+describe("main configuration resolution", () => {
+	const initialEnv = { ...process.env };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		process.env = { ...initialEnv };
+		delete process.env.PORT;
+		delete process.env.HOST;
+
+		mocks.args.mockReturnValue({
+			env: undefined,
+			port: undefined,
+			databaseUrl: "postgresql://localhost:5432/test",
+			varName: undefined,
+			open: false,
+			status: false,
+			help: false,
+			version: false,
+		});
+		mocks.loadEnv.mockResolvedValue({});
+		mocks.getDatabaseUrl.mockResolvedValue("postgresql://localhost:5432/test");
+		mocks.getDatabaseConnectionDetails.mockReturnValue({
+			type: "pg",
+			name: "PostgreSQL",
+			destination: "localhost:5432",
+		});
+		mocks.checkDatabaseConnection.mockResolvedValue(undefined);
+		mocks.shouldOpenBrowser.mockReturnValue(false);
+		mocks.createServer.mockReturnValue({ app: { fetch: vi.fn() } });
+	});
+
+	afterEach(() => {
+		process.env = { ...initialEnv };
+	});
+
+	it("reads PORT and HOST from .env when not supplied through environment or CLI", async () => {
+		mocks.loadEnv.mockResolvedValue({
+			PORT: "8080",
+			HOST: "127.0.0.1",
+		});
+
+		await main();
+
+		expect(mocks.serve).toHaveBeenCalledWith(
+			expect.objectContaining({
+				port: 8080,
+				hostname: "127.0.0.1",
+			}),
+		);
+		expect(process.env.PORT).toBe("8080");
+		expect(process.env.HOST).toBe("127.0.0.1");
+	});
+
+	it("preserves CLI port precedence over .env PORT", async () => {
+		mocks.args.mockReturnValue({
+			port: "9000",
+			databaseUrl: "postgresql://localhost:5432/test",
+		});
+		mocks.loadEnv.mockResolvedValue({
+			PORT: "8080",
+		});
+
+		await main();
+
+		expect(mocks.serve).toHaveBeenCalledWith(
+			expect.objectContaining({
+				port: 9000,
+			}),
+		);
+	});
+
+	it("preserves environment variables over .env PORT and HOST", async () => {
+		process.env.PORT = "7000";
+		process.env.HOST = "0.0.0.0";
+
+		mocks.loadEnv.mockResolvedValue({
+			PORT: "8080",
+			HOST: "127.0.0.1",
+		});
+
+		await main();
+
+		expect(mocks.serve).toHaveBeenCalledWith(
+			expect.objectContaining({
+				port: 7000,
+				hostname: "0.0.0.0",
+			}),
+		);
+	});
+
+	it("falls back to default PORT and undefined HOST when not configured", async () => {
+		mocks.loadEnv.mockResolvedValue({});
+
+		await main();
+
+		expect(mocks.serve).toHaveBeenCalledWith(
+			expect.objectContaining({
+				port: DEFAULTS.PORT,
+				hostname: undefined,
+			}),
+		);
+	});
+});

--- a/packages/server/tests/utils/create-server.test.ts
+++ b/packages/server/tests/utils/create-server.test.ts
@@ -189,12 +189,16 @@ describe("createServer", () => {
 
 		it("should allow localhost and *.localhost origins when NODE_ENV is development", async () => {
 			const originalEnv = process.env.NODE_ENV;
+			const originalOrigins = process.env.ALLOWED_ORIGINS;
 			try {
 				process.env.NODE_ENV = "development";
+				delete process.env.ALLOWED_ORIGINS;
 				const res1 = await server.app.request("/api/databases", {
 					headers: { Origin: "https://web.db-studio.localhost" },
 				});
-				expect(res1.headers.get("Access-Control-Allow-Origin")).toBe("https://web.db-studio.localhost");
+				expect(res1.headers.get("Access-Control-Allow-Origin")).toBe(
+					"https://web.db-studio.localhost",
+				);
 
 				const res2 = await server.app.request("/api/databases", {
 					headers: { Origin: "http://localhost:3000" },
@@ -211,7 +215,16 @@ describe("createServer", () => {
 				});
 				expect(resEvil.headers.get("Access-Control-Allow-Origin")).toBeNull();
 			} finally {
-				process.env.NODE_ENV = originalEnv;
+				if (originalEnv === undefined) {
+					delete process.env.NODE_ENV;
+				} else {
+					process.env.NODE_ENV = originalEnv;
+				}
+				if (originalOrigins === undefined) {
+					delete process.env.ALLOWED_ORIGINS;
+				} else {
+					process.env.ALLOWED_ORIGINS = originalOrigins;
+				}
 			}
 		});
 
@@ -222,9 +235,15 @@ describe("createServer", () => {
 				const res = await server.app.request("/api/databases", {
 					headers: { Origin: "https://custom.dbstudio.sh" },
 				});
-				expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://custom.dbstudio.sh");
+				expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+					"https://custom.dbstudio.sh",
+				);
 			} finally {
-				process.env.ALLOWED_ORIGINS = originalOrigins;
+				if (originalOrigins === undefined) {
+					delete process.env.ALLOWED_ORIGINS;
+				} else {
+					process.env.ALLOWED_ORIGINS = originalOrigins;
+				}
 			}
 		});
 	});

--- a/packages/server/tests/utils/create-server.test.ts
+++ b/packages/server/tests/utils/create-server.test.ts
@@ -186,6 +186,47 @@ describe("createServer", () => {
 			// OPTIONS should return without error
 			expect([200, 204, 404]).toContain(res.status);
 		});
+
+		it("should allow localhost and *.localhost origins when NODE_ENV is development", async () => {
+			const originalEnv = process.env.NODE_ENV;
+			try {
+				process.env.NODE_ENV = "development";
+				const res1 = await server.app.request("/api/databases", {
+					headers: { Origin: "https://web.db-studio.localhost" },
+				});
+				expect(res1.headers.get("Access-Control-Allow-Origin")).toBe("https://web.db-studio.localhost");
+
+				const res2 = await server.app.request("/api/databases", {
+					headers: { Origin: "http://localhost:3000" },
+				});
+				expect(res2.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:3000");
+
+				const res3 = await server.app.request("/api/databases", {
+					headers: { Origin: "http://127.0.0.1:5173" },
+				});
+				expect(res3.headers.get("Access-Control-Allow-Origin")).toBe("http://127.0.0.1:5173");
+
+				const resEvil = await server.app.request("/api/databases", {
+					headers: { Origin: "https://evil.example" },
+				});
+				expect(resEvil.headers.get("Access-Control-Allow-Origin")).toBeNull();
+			} finally {
+				process.env.NODE_ENV = originalEnv;
+			}
+		});
+
+		it("should allow origins configured in ALLOWED_ORIGINS", async () => {
+			const originalOrigins = process.env.ALLOWED_ORIGINS;
+			try {
+				process.env.ALLOWED_ORIGINS = "https://custom.dbstudio.sh, https://admin.dbstudio.sh";
+				const res = await server.app.request("/api/databases", {
+					headers: { Origin: "https://custom.dbstudio.sh" },
+				});
+				expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://custom.dbstudio.sh");
+			} finally {
+				process.env.ALLOWED_ORIGINS = originalOrigins;
+			}
+		});
 	});
 
 	describe("Pretty JSON middleware", () => {

--- a/packages/web/src/shared/api/client.ts
+++ b/packages/web/src/shared/api/client.ts
@@ -76,7 +76,16 @@ const setupInterceptors = (instance: AxiosInstance) => {
 };
 
 export const getBaseUrl = (): string => {
-	if (import.meta.env.DEV) return import.meta.env.VITE_API_URL ?? DEFAULTS.BASE_URL;
+	if (import.meta.env.VITE_API_URL) return import.meta.env.VITE_API_URL;
+	if (
+		import.meta.env.DEV &&
+		typeof window !== "undefined" &&
+		window.location?.hostname.endsWith(".localhost") &&
+		window.location.port
+	) {
+		return `${window.location.protocol}//api.db-studio.localhost:${window.location.port}`;
+	}
+	if (import.meta.env.DEV) return DEFAULTS.BASE_URL;
 	return globalThis.location?.origin ?? DEFAULTS.BASE_URL;
 };
 


### PR DESCRIPTION
Closes #259.

### What this PR does:
- Allows `localhost`, `*.localhost`, and `127.0.0.1` origins in CORS when `NODE_ENV === "development"` so the frontend can talk to the API out of the box during local development without needing manual `ALLOWED_ORIGINS` configuration.
- Adds `.env.example` at the project root with ready-to-use connection strings for all supported databases (PostgreSQL, MySQL, SQLite, SQL Server, MongoDB, Redis) and server dev options.
- Adds unit tests in `create-server.test.ts` to test development CORS origins and `ALLOWED_ORIGINS`.

### Verification:
- Ran `bun run format` (Biome)
- Ran `bun run typecheck`
- Ran `bun run test` (all 1025 tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an environment configuration template documenting database connection formats and optional server, AI proxy, rate-limiting, and web frontend settings.
  - Development environments support requests from localhost, localhost subdomains, and 127.0.0.1.
  - Approved origins can be configured for cross-origin access.
  - Web clients can use a configured API URL in development and production.

- **Bug Fixes**
  - Requests from unapproved origins are rejected, while requests without an origin continue to work.
  - Environment values load consistently without overriding existing settings.
  - Configuration values now follow the expected precedence across environment files, environment variables, and command-line options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->