### PR TITLE
fix(husky): make pre-commit hook cross-platform and include typecheck

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,27 @@
 # Ensure bun is in PATH across all operating systems (macOS, Linux, Windows) and environments
 if ! command -v bun >/dev/null 2>&1; then
-	export PATH="${BUN_INSTALL:-$HOME/.bun}/bin:${USERPROFILE:-$HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:$PATH"
+	# Convert a native Windows path (e.g. C:\Users\alice) to a POSIX path so
+	# it stays a single entry in Git Bash's colon-delimited PATH. POSIX paths
+	# pass through unchanged; when cygpath is missing, fall back to $HOME so
+	# a drive-letter colon never splits PATH.
+	to_posix_path() {
+		case "$1" in
+			[A-Za-z]:* | *\\*)
+				if command -v cygpath >/dev/null 2>&1; then
+					cygpath -u "$1"
+				else
+					printf '%s' "$HOME"
+				fi
+				;;
+			*)
+				printf '%s' "$1"
+				;;
+		esac
+	}
+
+	bun_install_bin="$(to_posix_path "${BUN_INSTALL:-$HOME/.bun}")/bin"
+	userprofile_bun_bin="$(to_posix_path "${USERPROFILE:-$HOME}")/.bun/bin"
+	export PATH="$bun_install_bin:$userprofile_bun_bin:/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:$PATH"
 fi
 
 if ! command -v bun >/dev/null 2>&1; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,14 @@
-export PATH="/Users/mac/.bun/bin:$PATH"
+# Ensure bun is in PATH across all operating systems (macOS, Linux, Windows) and environments
+if ! command -v bun >/dev/null 2>&1; then
+	export PATH="${BUN_INSTALL:-$HOME/.bun}/bin:${USERPROFILE:-$HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:$PATH"
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+	echo "husky - bun is not found in PATH. Please install Bun (https://bun.sh) or add it to PATH." >&2
+	exit 1
+fi
+
 bun run format
+bun run typecheck
 bun run test
 bun run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ Three export paths:
 
 - **Linter/Formatter**: Biome (tabs, 95-char width). Run `bun run format` to auto-fix.
 - **Tests**: Vitest (server package only). Path aliases `@` → `./src` and `@db-studio/shared` → `../shared/src` are configured in `vitest.config.ts`.
-- **Pre-commit hook**: runs `bun run format && bun run test && bun run build` via Husky.
+- **Pre-commit hook**: runs `bun run format && bun run typecheck && bun run test && bun run build` via Husky.
 - **CI**: GitHub Actions on push to `stage` — build → biome format → tests.
 
 ## Conventions


### PR DESCRIPTION
Closes #263.

### Summary
* Replaces hardcoded user path in `.husky/pre-commit` with dynamic resolution across macOS, Linux, and Windows.
* Adds `bun run typecheck` to pre-commit checks to catch TypeScript errors early.

### Verification
* Tested pre-commit hook in terminal and with restricted GUI PATH
* Verified all checks pass (`format`, `typecheck`, `test`, `build`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved pre-commit checks across macOS, Linux, and Windows.
  - Added clearer feedback when Bun is unavailable.
  - Added type checking to the pre-commit validation workflow.
  - Existing formatting, testing, and build checks continue to run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->