### PR TITLE
fix(web): allow column type dropdown to scroll in modal sheets

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "db-studio",
   "type": "module",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Modern database client for PostgreSQL with spreadsheet-like grid, AI-powered SQL assistance, ER diagrams, fast data browsing and editing. CLI tool, upcoming desktop & web versions.",
   "keywords": [
     "database client",

--- a/packages/ui/src/dialog-context.ts
+++ b/packages/ui/src/dialog-context.ts
@@ -1,0 +1,4 @@
+import * as React from "react";
+
+export const DialogContext = React.createContext<boolean>(false);
+export const useDialogContext = () => React.useContext(DialogContext);

--- a/packages/ui/src/primitives/command.tsx
+++ b/packages/ui/src/primitives/command.tsx
@@ -83,7 +83,7 @@ function CommandList({
 		<CommandPrimitive.List
 			data-slot="command-list"
 			className={cn(
-				"no-scrollbar max-h-72 scroll-py-1 outline-none overflow-x-hidden overflow-y-auto",
+				"max-h-72 scroll-py-1 outline-none overflow-x-hidden overflow-y-auto",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/primitives/date-picker.tsx
+++ b/packages/ui/src/primitives/date-picker.tsx
@@ -20,6 +20,7 @@ interface DatePickerProps {
 	icon?: boolean;
 	isFormatted?: boolean;
 	showTime?: boolean;
+	modal?: boolean;
 }
 
 export function DatePicker({
@@ -33,6 +34,7 @@ export function DatePicker({
 	icon = true,
 	isFormatted = true,
 	showTime = false,
+	modal,
 }: DatePickerProps) {
 	const [open, setOpen] = useState(false);
 	const [today] = useState<Date>(() => new Date());
@@ -110,6 +112,7 @@ export function DatePicker({
 
 	return (
 		<Popover
+			modal={modal}
 			open={open}
 			onOpenChange={setOpen}
 		>

--- a/packages/ui/src/primitives/dialog.tsx
+++ b/packages/ui/src/primitives/dialog.tsx
@@ -1,6 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import type * as React from "react";
+import { DialogContext } from "../dialog-context";
 import { cn } from "../utils";
 import { Button } from "./button";
 
@@ -75,7 +76,7 @@ function DialogContent({
 				)}
 				{...props}
 			>
-				{children}
+				<DialogContext.Provider value={true}>{children}</DialogContext.Provider>
 				{showCloseButton && (
 					<DialogPrimitive.Close
 						data-slot="dialog-close"

--- a/packages/ui/src/primitives/drawer.tsx
+++ b/packages/ui/src/primitives/drawer.tsx
@@ -1,6 +1,7 @@
 import type * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 
+import { DialogContext } from "../dialog-context";
 import { cn } from "../utils";
 
 function Drawer({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
@@ -73,7 +74,7 @@ function DrawerContent({
 				{...props}
 			>
 				{/* <div className="mx-auto mt-4 hidden h-1.5 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" /> */}
-				{children}
+				<DialogContext.Provider value={true}>{children}</DialogContext.Provider>
 			</DrawerPrimitive.Content>
 		</DrawerPortal>
 	);

--- a/packages/ui/src/primitives/popover.tsx
+++ b/packages/ui/src/primitives/popover.tsx
@@ -1,12 +1,15 @@
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import type * as React from "react";
 
+import { useDialogContext } from "../dialog-context";
 import { cn } from "../utils";
 
-function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+function Popover({ modal, ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+	const inDialog = useDialogContext();
 	return (
 		<PopoverPrimitive.Root
 			data-slot="popover"
+			modal={modal ?? (inDialog ? true : undefined)}
 			{...props}
 		/>
 	);

--- a/packages/ui/src/primitives/sheet.tsx
+++ b/packages/ui/src/primitives/sheet.tsx
@@ -1,6 +1,7 @@
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import type * as React from "react";
+import { DialogContext } from "../dialog-context";
 import { cn } from "../utils";
 import { Button } from "./button";
 
@@ -81,7 +82,7 @@ function SheetContent({
 				)}
 				{...props}
 			>
-				{children}
+				<DialogContext.Provider value={true}>{children}</DialogContext.Provider>
 				{showCloseButton && (
 					<SheetPrimitive.Close
 						data-slot="sheet-close"

--- a/packages/web/src/features/records/components/referenced-table-filter-popup.tsx
+++ b/packages/web/src/features/records/components/referenced-table-filter-popup.tsx
@@ -89,6 +89,7 @@ export const ReferencedTableFilterPopup = ({ tableName }: { tableName: string })
 
 	return (
 		<Popover
+			modal={true}
 			open={isOpen}
 			onOpenChange={handleOpenChange}
 		>

--- a/packages/web/src/features/records/components/referenced-table-sort-popup.tsx
+++ b/packages/web/src/features/records/components/referenced-table-sort-popup.tsx
@@ -75,6 +75,7 @@ export const ReferencedTableSortPopup = ({ tableName }: { tableName: string }) =
 
 	return (
 		<Popover
+			modal={true}
 			open={isOpen}
 			onOpenChange={handleOpenChange}
 		>

--- a/packages/web/src/features/table-builder/components/add-foreign-key/referenced-table-field.tsx
+++ b/packages/web/src/features/table-builder/components/add-foreign-key/referenced-table-field.tsx
@@ -46,6 +46,7 @@ export const ReferencedTableField = ({ index }: { index: number }) => {
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="referencedTable">Select a table to reference to</Label>
 					<Popover
+						modal={true}
 						onOpenChange={(isOpen) => {
 							if (isOpen) {
 								ensureForeignKeyExists();

--- a/packages/web/src/features/table-builder/components/fields/column-type-field.tsx
+++ b/packages/web/src/features/table-builder/components/fields/column-type-field.tsx
@@ -38,6 +38,7 @@ export const ColumnTypeField = ({ index }: { index: number }) => {
 			name={`fields.${index}.columnType`}
 			render={({ field }) => (
 				<Popover
+					modal={true}
 					open={typePickerOpen}
 					onOpenChange={setTypePickerOpen}
 				>

--- a/www/src/lib/content/changelog.ts
+++ b/www/src/lib/content/changelog.ts
@@ -16,6 +16,17 @@ export type ChangelogItem = {
 
 export const changelog: ChangelogItem[] = [
 	{
+		version: "1.10.1",
+		date: "2026-09-04",
+		title: "Fix scrolling in column type dropdowns",
+		bugsFixed: [
+			{
+				text: "Fixed column type dropdowns not scrolling with a mouse wheel or trackpad inside table, add-column, and edit-column overlays",
+				username: "marwan562",
+			},
+		],
+	},
+	{
 		version: "1.10.0",
 		date: "2026-08-28",
 		title: "Support Redis key browsing",


### PR DESCRIPTION
Closes #265.

Fixes an issue where the column type dropdown couldn't be scrolled with a mouse wheel or trackpad when opened inside sheets and dialogs like Table Builder.

Popovers now inherit modal behavior when rendered inside dialogs and sheets so Radix's scroll lock doesn't intercept wheel events, and removed the no-scrollbar class from CommandList so the list can scroll normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added modal behavior for popovers used within dialogs, drawers, and sheets.
  * Enabled modal interactions for record filters, sorting, referenced-table selection, and column type selection.
  * Added optional modal support to date pickers.

* **Bug Fixes**
  * Fixed column type dropdowns so they scroll correctly with a mouse wheel or trackpad.
  * Improved overlay behavior by preventing background interaction while relevant popovers are open.
  * Restored standard scrolling behavior in command lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->