### PR TITLE
fix(front): repair Edit Table navigation and return to data

### DIFF
--- a/packages/web/src/components/components/tabs.tsx
+++ b/packages/web/src/components/components/tabs.tsx
@@ -1,36 +1,47 @@
 import { Button } from "@db-studio/ui/button";
 import { cn } from "@db-studio/ui/utils";
-import { Link, useLocation } from "@tanstack/react-router";
+import { Link, useLocation, useParams } from "@tanstack/react-router";
 import { useDatabaseStore } from "@/stores/database.store";
 import { TABS } from "@/utils/constants";
 
 export const Tabs = () => {
 	const { pathname } = useLocation();
+	const params = useParams({ strict: false });
 	const currentRoute = pathname.split("/")[1] || "table";
 	const { dbType } = useDatabaseStore();
 	const routes = dbType === "redis" ? (["browser", "runner"] as const) : TABS;
+	const activeTable = (params as { table?: string }).table;
 
 	return (
 		<div className="flex h-full items-center">
-			{routes.map((route) => (
-				<Link
-					key={route}
-					to={`/${route}`}
-					className="h-full flex items-center"
-				>
-					<Button
-						variant="ghost"
-						className={cn(
-							"flex-1 px-4 border-l-0 border-y-0 border-r border-border h-full rounded-none capitalize text-xs font-medium transition-colors",
-							currentRoute === route
-								? "bg-muted text-foreground"
-								: "text-muted-foreground hover:text-foreground hover:bg-muted/50",
-						)}
+			{routes.map((route) => {
+				// Keep the selected table when switching between the table data
+				// view and the schema (edit table) view, so exiting edit mode
+				// doesn't lose context (previously this went to /table with no
+				// selection, leaving users stuck in schema mode).
+				const keepTable = (route === "table" || route === "schema") && activeTable;
+
+				return (
+					<Link
+						key={route}
+						to={keepTable ? `/${route}/$table` : `/${route}`}
+						params={keepTable ? { table: activeTable as string } : undefined}
+						className="h-full flex items-center"
 					>
-						{route}
-					</Button>
-				</Link>
-			))}
+						<Button
+							variant="ghost"
+							className={cn(
+								"flex-1 px-4 border-l-0 border-y-0 border-r border-border h-full rounded-none capitalize text-xs font-medium transition-colors",
+								currentRoute === route
+									? "bg-muted text-foreground"
+									: "text-muted-foreground hover:text-foreground hover:bg-muted/50",
+							)}
+						>
+							{route}
+						</Button>
+					</Link>
+				);
+			})}
 		</div>
 	);
 };

--- a/packages/web/src/components/sidebar/sidebar-list-tables-item.tsx
+++ b/packages/web/src/components/sidebar/sidebar-list-tables-item.tsx
@@ -17,29 +17,40 @@ export const SidebarListTablesItem = ({
 	const basePath = pathname.startsWith("/schema") ? "/schema/$table" : "/table/$table";
 
 	return (
-		<li className="relative">
-			<Link
-				to={basePath}
-				params={{
-					table: tableName,
-				}}
+		<li className="relative group">
+			{isActive && <span className="absolute left-0 top-0 bottom-0 w-1 bg-primary z-10" />}
+			<div
 				className={cn(
-					"w-full flex gap-0.5 px-4 py-1.5 text-sm transition-colors text-left justify-start items-center focus:outline-none",
+					"w-full flex gap-0.5 pl-4 pr-2 py-1.5 text-sm transition-colors text-left justify-start items-center focus:outline-none",
 					isActive
 						? "text-sidebar-accent-foreground bg-sidebar-accent font-medium"
 						: "text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent/50 focus:bg-sidebar-accent focus:text-sidebar-accent-foreground",
 				)}
 			>
-				{isActive && <span className="absolute left-0 top-0 bottom-0 w-1 bg-primary" />}
-				<span className="flex-1 truncate">
-					{schemaName && schemaName !== "public" ? `${schemaName}.` : ""}
-					{tableName}
-				</span>
-				<div className="flex items-center gap-1 h-5">
-					{isActive && <SidebarListTablesMenu tableName={tableName} />}
+				<Link
+					to={basePath}
+					params={{
+						table: tableName,
+					}}
+					className="flex-1 flex items-center gap-1 min-w-0 focus:outline-none"
+				>
+					<span className="flex-1 truncate">
+						{schemaName && schemaName !== "public" ? `${schemaName}.` : ""}
+						{tableName}
+					</span>
 					<Kbd>{rowCount}</Kbd>
+				</Link>
+				<div
+					className={cn(
+						"flex items-center h-5 shrink-0",
+						isActive
+							? "opacity-100"
+							: "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+					)}
+				>
+					<SidebarListTablesMenu tableName={tableName} />
 				</div>
-			</Link>
+			</div>
 		</li>
 	);
 };

--- a/packages/web/src/components/sidebar/sidebar-list-tables-menu.tsx
+++ b/packages/web/src/components/sidebar/sidebar-list-tables-menu.tsx
@@ -74,10 +74,19 @@ export const SidebarListTablesMenu = ({ tableName }: { tableName: string }) => {
 	return (
 		<>
 			<DropdownMenu>
-				<DropdownMenuTrigger>
+				<DropdownMenuTrigger asChild>
 					<Button
 						variant="ghost"
 						size="icon-sm"
+						onClick={(e) => {
+							// Prevent the parent sidebar <Link> from navigating
+							// when opening the row actions menu.
+							e.stopPropagation();
+							e.preventDefault();
+						}}
+						onPointerDown={(e) => {
+							e.stopPropagation();
+						}}
 					>
 						<EllipsisVertical />
 					</Button>

--- a/packages/web/src/features/schema/components/schema-toolbar.tsx
+++ b/packages/web/src/features/schema/components/schema-toolbar.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@db-studio/ui/button";
-import { Plus, RefreshCw } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { Plus, RefreshCw, Table2 } from "lucide-react";
 import { useIsSchemaless } from "@/hooks/use-is-schemaless";
 import { useOverlayStore } from "@/stores/overlay.store";
 
@@ -26,6 +27,21 @@ export const SchemaToolbar = ({
 				disabled={isRefetching}
 			>
 				<RefreshCw className="size-4" />
+			</Button>
+
+			<Button
+				variant="ghost"
+				asChild
+				className="h-8! border-l border-y-0 border-r-0 border-border rounded-none flex items-center gap-2 text-muted-foreground hover:text-foreground"
+			>
+				<Link
+					to="/table/$table"
+					params={{ table: tableName }}
+					aria-label={`View data for ${tableName}`}
+				>
+					<Table2 className="size-4" />
+					View data
+				</Link>
 			</Button>
 
 			{!isSchemaless && (


### PR DESCRIPTION
Closes #279.

The sidebar Edit Table item never navigated because its dropdown trigger was a button nested inside the row link, so clicks never reached the menu action. I moved the menu out of the link and gave the trigger asChild, so it works for every table now.

The schema view also had no way back. The header table tab did not keep the selected table, so it dumped you on an empty view. Tabs now keep the table when switching between table and schema, and there's a View data button in the schema toolbar.

Checked with `bun run typecheck` and `bun run test:server` (1036 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **View data** button to the schema editor for quick access to the selected table’s data.
  - Preserved the selected table when switching between data and schema views.
  - Table row actions are now available on hover or focus, improving discoverability.
- **Bug Fixes**
  - Prevented opening a table’s action menu from triggering navigation to the table.
  - Improved sidebar interaction by keeping table actions separate from the table link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->