### PR TITLE
feat(tables): add rename table across all databases

### DIFF
--- a/packages/server/src/adapters/adapter.interface.ts
+++ b/packages/server/src/adapters/adapter.interface.ts
@@ -19,6 +19,7 @@ import type {
 	ExecuteQueryResult,
 	FilterType,
 	RenameColumnParamsSchemaType,
+	RenameTableParamsSchemaType,
 	SortDirection,
 	SortType,
 	TableDataResultSchemaType,
@@ -50,6 +51,7 @@ export interface IDbAdapter {
 		db: DatabaseSchemaType["db"];
 	}): Promise<void>;
 	deleteTable(params: DeleteTableParams): Promise<DeleteTableResult>;
+	renameTable(params: RenameTableParamsSchemaType): Promise<void>;
 	getTableSchema(params: { tableName: string; db: DatabaseSchemaType["db"] }): Promise<string>;
 
 	// --- Columns ---

--- a/packages/server/src/adapters/base.adapter.ts
+++ b/packages/server/src/adapters/base.adapter.ts
@@ -19,6 +19,7 @@ import type {
 	DeleteTableResult,
 	ExecuteQueryResult,
 	RenameColumnParamsSchemaType,
+	RenameTableParamsSchemaType,
 	TableDataResultSchemaType,
 	TableInfoSchemaType,
 	UpdateRecordsSchemaType,
@@ -248,6 +249,9 @@ export abstract class BaseAdapter implements IDbAdapter {
 	}
 	deleteTable(_params: DeleteTableParams): Promise<DeleteTableResult> {
 		return notImplemented("deleteTable");
+	}
+	renameTable(_params: RenameTableParamsSchemaType): Promise<void> {
+		return notImplemented("renameTable");
 	}
 	getTableSchema(_params: {
 		tableName: string;

--- a/packages/server/src/adapters/mongo/mongo.adapter.ts
+++ b/packages/server/src/adapters/mongo/mongo.adapter.ts
@@ -17,6 +17,7 @@ import type {
 	DeleteTableResult,
 	ExecuteQueryResult,
 	RenameColumnParamsSchemaType,
+	RenameTableParamsSchemaType,
 	TableDataResultSchemaType,
 	TableInfoSchemaType,
 	UpdateRecordsSchemaType,
@@ -547,6 +548,33 @@ export class MongoAdapter extends BaseAdapter {
 			const rowCount = await collection.estimatedDocumentCount();
 			await collection.drop();
 			return { deletedCount: rowCount, fkViolation: false, relatedRecords: [] };
+		} catch (e) {
+			throw this.wrapError(e);
+		}
+	}
+
+	override async renameTable(params: RenameTableParamsSchemaType): Promise<void> {
+		try {
+			const { tableName, newTableName, db } = params;
+			if (tableName === newTableName) {
+				throw new HTTPException(400, {
+					message: `New table name must be different from "${tableName}"`,
+				});
+			}
+			const mongoDb = await getMongoDb(db);
+			const existing = await mongoDb.listCollections({ name: tableName }).toArray();
+			if (existing.length === 0) {
+				throw new HTTPException(404, {
+					message: `Collection "${tableName}" does not exist`,
+				});
+			}
+			const target = await mongoDb.listCollections({ name: newTableName }).toArray();
+			if (target.length > 0) {
+				throw new HTTPException(409, {
+					message: `Collection "${newTableName}" already exists`,
+				});
+			}
+			await mongoDb.collection(tableName).rename(newTableName);
 		} catch (e) {
 			throw this.wrapError(e);
 		}

--- a/packages/server/src/adapters/mssql/mssql.adapter.ts
+++ b/packages/server/src/adapters/mssql/mssql.adapter.ts
@@ -22,6 +22,7 @@ import type {
 	ForeignKeyDataType,
 	RelatedRecord,
 	RenameColumnParamsSchemaType,
+	RenameTableParamsSchemaType,
 	TableDataResultSchemaType,
 	TableInfoSchemaType,
 	UpdateRecordsSchemaType,
@@ -373,6 +374,40 @@ export class MsSqlAdapter extends BaseAdapter {
 			}
 			if (error instanceof HTTPException) throw error;
 			throw new HTTPException(500, { message: `Failed to delete table "${tableName}"` });
+		}
+	}
+
+	async renameTable(params: RenameTableParamsSchemaType): Promise<void> {
+		try {
+			const { tableName, newTableName, db } = params;
+			if (tableName === newTableName)
+				throw new HTTPException(400, {
+					message: `New table name must be different from "${tableName}"`,
+				});
+			const pool = await getMssqlPool(db);
+
+			await this.assertTableExists(pool, tableName);
+
+			const targetCheck = await pool
+				.request()
+				.input("tableName", newTableName)
+				.query(`
+					SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.TABLES
+					WHERE TABLE_CATALOG = DB_NAME() AND TABLE_NAME = @tableName AND TABLE_SCHEMA = 'dbo'
+				`);
+			if (Number(targetCheck.recordset[0]?.cnt ?? 0) > 0) {
+				throw new HTTPException(409, {
+					message: `Table "${newTableName}" already exists`,
+				});
+			}
+
+			await pool
+				.request()
+				.input("oldName", tableName)
+				.input("newName", newTableName)
+				.query("EXEC sp_rename @oldName, @newName");
+		} catch (e) {
+			throw this.wrapError(e);
 		}
 	}
 

--- a/packages/server/src/adapters/mysql/mysql.adapter.ts
+++ b/packages/server/src/adapters/mysql/mysql.adapter.ts
@@ -24,6 +24,7 @@ import type {
 	ForeignKeyDataType,
 	RelatedRecord,
 	RenameColumnParamsSchemaType,
+	RenameTableParamsSchemaType,
 	SortDirection,
 	TableInfoSchemaType,
 	UpdateRecordsSchemaType,
@@ -479,6 +480,35 @@ export class MySqlAdapter extends BaseAdapter {
 			}
 			if (error instanceof HTTPException) throw error;
 			throw new HTTPException(500, { message: `Failed to delete table "${tableName}"` });
+		}
+	}
+
+	async renameTable(params: RenameTableParamsSchemaType): Promise<void> {
+		try {
+			const { tableName, newTableName, db } = params;
+			if (tableName === newTableName)
+				throw new HTTPException(400, {
+					message: `New table name must be different from "${tableName}"`,
+				});
+			const pool = getMysqlPool(db);
+
+			await this.assertTableExists(pool, tableName);
+
+			const [targetRows] = await pool.execute<RowDataPacket[]>(
+				`SELECT COUNT(*) as cnt FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`,
+				[newTableName],
+			);
+			if (Number((targetRows as Array<{ cnt: number }>)[0]?.cnt ?? 0) > 0) {
+				throw new HTTPException(409, {
+					message: `Table "${newTableName}" already exists`,
+				});
+			}
+
+			await pool.execute<ResultSetHeader>(
+				`RENAME TABLE \`${tableName.replaceAll("`", "``")}\` TO \`${newTableName.replaceAll("`", "``")}\``,
+			);
+		} catch (e) {
+			throw this.wrapError(e);
 		}
 	}
 

--- a/packages/server/src/adapters/pg/pg.adapter.ts
+++ b/packages/server/src/adapters/pg/pg.adapter.ts
@@ -24,6 +24,7 @@ import type {
 	ForeignKeyDataType,
 	RelatedRecord,
 	RenameColumnParamsSchemaType,
+	RenameTableParamsSchemaType,
 	SortDirection,
 	TableInfoSchemaType,
 	UpdateRecordsSchemaType,
@@ -509,6 +510,48 @@ export class PgAdapter extends BaseAdapter {
 			}
 			if (error instanceof HTTPException) throw error;
 			throw new HTTPException(500, { message: `Failed to delete table "${tableName}"` });
+		}
+	}
+
+	async renameTable(params: RenameTableParamsSchemaType): Promise<void> {
+		try {
+			const { tableName, newTableName, db } = params;
+			if (tableName === newTableName)
+				throw new HTTPException(400, {
+					message: `New table name must be different from "${tableName}"`,
+				});
+			const pool = getDbPool(db);
+
+			// Tables are listed from every user schema, so resolve the actual schema
+			// instead of assuming "public".
+			const { rows: schemaRows } = await pool.query(
+				`SELECT table_schema as "schemaName" FROM information_schema.tables WHERE table_name = $1 AND table_schema NOT IN ('pg_catalog', 'information_schema') AND table_schema NOT LIKE 'pg_toast%';`,
+				[tableName],
+			);
+			const schemas = (schemaRows as Array<{ schemaName: string }>).map((r) => r.schemaName);
+			if (schemas.length === 0)
+				throw new HTTPException(404, { message: `Table "${tableName}" does not exist` });
+			if (schemas.length > 1 && !schemas.includes("public"))
+				throw new HTTPException(400, {
+					message: `Table "${tableName}" exists in multiple schemas (${schemas.join(", ")}); rename is ambiguous`,
+				});
+			// Prefer "public" when the name exists in several schemas (previous behavior).
+			const schemaName = schemas.includes("public") ? "public" : (schemas[0] as string);
+
+			const { rows: targetRows } = await pool.query(
+				`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = $1 AND table_schema = $2) as exists;`,
+				[newTableName, schemaName],
+			);
+			if (targetRows[0]?.exists)
+				throw new HTTPException(409, {
+					message: `Table "${newTableName}" already exists`,
+				});
+
+			await pool.query(
+				`ALTER TABLE "${schemaName.replaceAll('"', '""')}"."${tableName.replaceAll('"', '""')}" RENAME TO "${newTableName.replaceAll('"', '""')}"`,
+			);
+		} catch (e) {
+			throw this.wrapError(e);
 		}
 	}
 

--- a/packages/server/src/adapters/redis/redis.adapter.ts
+++ b/packages/server/src/adapters/redis/redis.adapter.ts
@@ -30,6 +30,7 @@ import type {
 	KeyWriteResultSchemaType,
 	RedisKeyTypeSchemaType,
 	RenameColumnParamsSchemaType,
+	RenameTableParamsSchemaType,
 	TableDataResultSchemaType,
 	TableInfoSchemaType,
 	UpdateRecordsSchemaType,
@@ -1027,6 +1028,10 @@ export class RedisAdapter extends BaseAdapter implements IKeyValueAdapter {
 			message:
 				"Bulk deletion of Redis tables is not supported. Use FLUSHDB from the query runner to clear the entire logical database.",
 		});
+	}
+
+	override async renameTable(_params: RenameTableParamsSchemaType): Promise<void> {
+		throw new HTTPException(400, { message: SCHEMA_MUTATION_MESSAGE });
 	}
 
 	override async getTableSchema({

--- a/packages/server/src/adapters/sqlite/sqlite.adapter.ts
+++ b/packages/server/src/adapters/sqlite/sqlite.adapter.ts
@@ -23,6 +23,7 @@ import type {
 	ForeignKeyDataType,
 	RelatedRecord,
 	RenameColumnParamsSchemaType,
+	RenameTableParamsSchemaType,
 	SortDirection,
 	TableInfoSchemaType,
 	UpdateRecordsSchemaType,
@@ -514,6 +515,43 @@ export class SqliteAdapter extends BaseAdapter {
 			if (error instanceof HTTPException) throw error;
 			throw new HTTPException(500, { message: `Failed to delete table "${tableName}"` });
 		}
+	}
+
+	async renameTable(params: RenameTableParamsSchemaType): Promise<void> {
+		const { tableName, newTableName, db } = params;
+		if (tableName === newTableName)
+			throw new HTTPException(400, {
+				message: `New table name must be different from "${tableName}"`,
+			});
+		const sqliteDb = getSqliteDb();
+
+		const tableRow = sqliteDb
+			.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+			.get(tableName);
+		if (!tableRow)
+			throw new HTTPException(404, { message: `Table "${tableName}" does not exist` });
+
+		const targetRow = sqliteDb
+			.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+			.get(newTableName);
+		if (targetRow)
+			throw new HTTPException(409, {
+				message: `Table "${newTableName}" already exists`,
+			});
+
+		try {
+			// Identifiers cannot be bound as parameters — escape the quote character.
+			const escapeIdent = (s: string) => s.replaceAll('"', '""');
+			sqliteDb
+				.prepare(
+					`ALTER TABLE "${escapeIdent(tableName)}" RENAME TO "${escapeIdent(newTableName)}"`,
+				)
+				.run();
+		} catch (e) {
+			throw this.wrapError(e);
+		}
+
+		void db;
 	}
 
 	async getTableSchema({

--- a/packages/server/src/routes/tables.routes.ts
+++ b/packages/server/src/routes/tables.routes.ts
@@ -10,6 +10,7 @@ import {
 	deleteTableQuerySchema,
 	exportTableSchema,
 	renameColumnSchema,
+	renameTableSchema,
 	type TableDataResultSchemaType,
 	type TableInfoSchemaType,
 	type TableSchemaResult,
@@ -77,6 +78,33 @@ export const tablesRoutes = new Hono<RouteEnv>()
 			const dao = getAdapter(dbType);
 			const result = await dao.deleteTable({ tableName, db, cascade });
 			return c.json({ data: result }, 200);
+		},
+	)
+
+	/**
+	 * PATCH /tables/:tableName/rename
+	 * Renames a table
+	 */
+	.patch(
+		"/:tableName/rename",
+		zValidator("query", databaseSchema),
+		zValidator("param", tableNameSchema),
+		zValidator("json", renameTableSchema),
+		async (c): ApiHandler<string> => {
+			const { db } = c.req.valid("query");
+			const { tableName } = c.req.valid("param");
+			const body = c.req.valid("json");
+			const dbType = c.get("dbType");
+
+			const dao = getAdapter(dbType);
+			await dao.renameTable({ tableName, db, ...body });
+
+			return c.json(
+				{
+					data: `Table "${tableName}" renamed to "${body.newTableName}"`,
+				},
+				200,
+			);
 		},
 	)
 

--- a/packages/server/src/utils/create-server.ts
+++ b/packages/server/src/utils/create-server.ts
@@ -109,7 +109,7 @@ export const createServer = () => {
 					}
 					return undefined;
 				},
-				allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+				allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
 				allowHeaders: [
 					"Content-Type",
 					"X-Run-Id",
@@ -120,6 +120,7 @@ export const createServer = () => {
 					"x-byok-grok",
 					"x-byok-openrouter",
 				],
+				maxAge: 600,
 			}),
 		)
 

--- a/packages/server/tests/adapters/mongo.adapter.test.ts
+++ b/packages/server/tests/adapters/mongo.adapter.test.ts
@@ -52,6 +52,7 @@ function createMongoMocks() {
 		deleteOne: vi.fn(async () => ({ deletedCount: 1 })),
 		deleteMany: vi.fn(async () => ({ deletedCount: 1 })),
 		drop: vi.fn(async () => true),
+		rename: vi.fn(async () => ({})),
 	};
 
 	const mongoDb = {
@@ -361,5 +362,44 @@ describe("MongoAdapter integration scaffold", () => {
 		expect(
 			(adapter as { buildCursors: () => { nextCursor: null; prevCursor: null } }).buildCursors(),
 		).toEqual({ nextCursor: null, prevCursor: null });
+	});
+});
+
+describe("MongoAdapter.renameTable", () => {
+	let adapter: MongoAdapter;
+	let mocks: ReturnType<typeof createMongoMocks>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		adapter = new MongoAdapter();
+		mocks = createMongoMocks();
+		mockGetMongoDb.mockResolvedValue(mocks.mongoDb);
+	});
+
+	it("renames an existing collection via the driver rename", async () => {
+		await adapter.renameTable({ db: "appdb", tableName: "users", newTableName: "new_users" });
+		expect(mocks.mongoDb.collection).toHaveBeenCalledWith("users");
+		expect(mocks.collection.rename).toHaveBeenCalledWith("new_users");
+	});
+
+	it("returns 404 when the collection does not exist", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "empty", newTableName: "people" }),
+		).rejects.toMatchObject({ status: 404 });
+		expect(mocks.collection.rename).not.toHaveBeenCalled();
+	});
+
+	it("returns 409 when the target collection already exists", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "users", newTableName: "orders" }),
+		).rejects.toMatchObject({ status: 409 });
+		expect(mocks.collection.rename).not.toHaveBeenCalled();
+	});
+
+	it("returns 400 when the new name equals the current name", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "users", newTableName: "users" }),
+		).rejects.toMatchObject({ status: 400 });
+		expect(mocks.collection.rename).not.toHaveBeenCalled();
 	});
 });

--- a/packages/server/tests/adapters/mssql.adapter.test.ts
+++ b/packages/server/tests/adapters/mssql.adapter.test.ts
@@ -430,3 +430,71 @@ describe("MsSqlAdapter integration scaffold", () => {
 		});
 	});
 });
+
+describe("MsSqlAdapter.renameTable", () => {
+	let adapter: MsSqlAdapter;
+	let statements: string[];
+	let boundParams: Record<string, unknown>[];
+	const existing = ["users", "orders"];
+
+	const createRenamePool = () => {
+		const pool = {
+			request: vi.fn(() => {
+				const params: Record<string, unknown> = {};
+				boundParams.push(params);
+				const req = {
+					input: vi.fn((name: string, value: unknown) => {
+						params[name] = value;
+						return req;
+					}),
+					query: vi.fn(async (sql: string) => {
+						const text = String(sql);
+						statements.push(text);
+						if (text.includes("INFORMATION_SCHEMA.TABLES") && text.includes("COUNT(*) as cnt")) {
+							return {
+								recordset: [{ cnt: existing.includes(params.tableName as string) ? 1 : 0 }],
+								rowsAffected: [0],
+							};
+						}
+						return { recordset: [], rowsAffected: [1] };
+					}),
+				};
+				return req;
+			}),
+		};
+		return pool;
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		adapter = new MsSqlAdapter();
+		statements = [];
+		boundParams = [];
+		mockGetMssqlPool.mockResolvedValue(createRenamePool());
+	});
+
+	it("renames via parameterized sp_rename (no string interpolation)", async () => {
+		await adapter.renameTable({ db: "appdb", tableName: "users", newTableName: "members" });
+		expect(statements.at(-1)).toBe("EXEC sp_rename @oldName, @newName");
+		const renameParams = boundParams.at(-1);
+		expect(renameParams).toMatchObject({ oldName: "users", newName: "members" });
+	});
+
+	it("returns 404 when the table does not exist", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "ghost", newTableName: "spook" }),
+		).rejects.toMatchObject({ status: 404 });
+	});
+
+	it("returns 409 when the target table already exists", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "users", newTableName: "orders" }),
+		).rejects.toMatchObject({ status: 409 });
+	});
+
+	it("returns 400 when the new name equals the current name", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "users", newTableName: "users" }),
+		).rejects.toMatchObject({ status: 400 });
+	});
+});

--- a/packages/server/tests/adapters/mysql.adapter.test.ts
+++ b/packages/server/tests/adapters/mysql.adapter.test.ts
@@ -448,3 +448,55 @@ describe("MySqlAdapter integration scaffold", () => {
 		});
 	});
 });
+
+describe("MySqlAdapter.renameTable", () => {
+	let adapter: MySqlAdapter;
+	let statements: string[];
+	const existing = ["users", "orders", "we`ird"];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		adapter = new MySqlAdapter();
+		statements = [];
+		const pool = {
+			getConnection: vi.fn(),
+			execute: vi.fn(async (sql: string, values?: unknown[]) => {
+				const text = String(sql);
+				statements.push(text);
+				if (text.includes("information_schema.TABLES") && text.includes("COUNT(*) as cnt")) {
+					return rows([{ cnt: existing.includes(values?.[0] as string) ? 1 : 0 }]);
+				}
+				return ok(1);
+			}),
+		};
+		mockGetMysqlPool.mockReturnValue(pool);
+	});
+
+	it("renames an existing table with RENAME TABLE", async () => {
+		await adapter.renameTable({ db: "appdb", tableName: "users", newTableName: "members" });
+		expect(statements.at(-1)).toBe("RENAME TABLE `users` TO `members`");
+	});
+
+	it("escapes backticks in identifiers", async () => {
+		await adapter.renameTable({ db: "appdb", tableName: "we`ird", newTableName: "ok" });
+		expect(statements.at(-1)).toBe("RENAME TABLE `we``ird` TO `ok`");
+	});
+
+	it("returns 404 when the table does not exist", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "ghost", newTableName: "spook" }),
+		).rejects.toMatchObject({ status: 404 });
+	});
+
+	it("returns 409 when the target table already exists", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "users", newTableName: "orders" }),
+		).rejects.toMatchObject({ status: 409 });
+	});
+
+	it("returns 400 when the new name equals the current name", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "users", newTableName: "users" }),
+		).rejects.toMatchObject({ status: 400 });
+	});
+});

--- a/packages/server/tests/adapters/pg.adapter.test.ts
+++ b/packages/server/tests/adapters/pg.adapter.test.ts
@@ -547,3 +547,78 @@ describe("PgAdapter integration scaffold", () => {
 		]);
 	});
 });
+
+describe("PgAdapter.renameTable", () => {
+	let adapter: PgAdapter;
+	let statements: string[];
+
+	// Simulated information_schema: which schemas contain each table name.
+	const schemasByTable: Record<string, string[]> = {
+		users: ["public"],
+		product: ["analytics"],
+		item: ["analytics"],
+		legacy: ["archive", "backup"],
+		'we"ird': ["public"],
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		adapter = new PgAdapter();
+		statements = [];
+		const pool = {
+			query: vi.fn(async (sql: string, values?: unknown[]) => {
+				const text = String(sql);
+				statements.push(text);
+				if (text.includes('table_schema as "schemaName"')) {
+					const name = values?.[0] as string;
+					return result((schemasByTable[name] ?? []).map((s) => ({ schemaName: s })));
+				}
+				if (text.includes("SELECT EXISTS") && text.includes("information_schema.tables")) {
+					const [target, schema] = values as [string, string];
+					return result([{ exists: (schemasByTable[target] ?? []).includes(schema) }]);
+				}
+				return result([]);
+			}),
+		};
+		mockGetDbPool.mockReturnValue(pool);
+	});
+
+	it("renames a public table", async () => {
+		await adapter.renameTable({ db: "appdb", tableName: "users", newTableName: "members" });
+		expect(statements.at(-1)).toBe('ALTER TABLE "public"."users" RENAME TO "members"');
+	});
+
+	it("renames a table living in a non-public schema", async () => {
+		await adapter.renameTable({ db: "appdb", tableName: "product", newTableName: "goods" });
+		expect(statements.at(-1)).toBe('ALTER TABLE "analytics"."product" RENAME TO "goods"');
+	});
+
+	it("escapes double quotes in identifiers", async () => {
+		await adapter.renameTable({ db: "appdb", tableName: 'we"ird', newTableName: "ok" });
+		expect(statements.at(-1)).toBe('ALTER TABLE "public"."we""ird" RENAME TO "ok"');
+	});
+
+	it("returns 404 when the table does not exist in any schema", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "ghost", newTableName: "spook" }),
+		).rejects.toMatchObject({ status: 404 });
+	});
+
+	it("returns 409 when the target name exists in the same schema", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "product", newTableName: "item" }),
+		).rejects.toMatchObject({ status: 409 });
+	});
+
+	it("returns 400 when the new name equals the current name", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "users", newTableName: "users" }),
+		).rejects.toMatchObject({ status: 400 });
+	});
+
+	it("returns 400 when the table exists in multiple non-public schemas", async () => {
+		await expect(
+			adapter.renameTable({ db: "appdb", tableName: "legacy", newTableName: "modern" }),
+		).rejects.toMatchObject({ status: 400 });
+	});
+});

--- a/packages/server/tests/adapters/redis/redis.adapter.tables.test.ts
+++ b/packages/server/tests/adapters/redis/redis.adapter.tables.test.ts
@@ -159,6 +159,11 @@ describe("RedisAdapter — tables", () => {
 						newColumnName: "v",
 					}),
 			},
+			{
+				name: "renameTable",
+				call: () =>
+					adapter.renameTable({ db: "0", tableName: "strings", newTableName: "texts" }),
+			},
 		];
 
 		for (const { name, call } of cases) {

--- a/packages/server/tests/adapters/sqlite.adapter.test.ts
+++ b/packages/server/tests/adapters/sqlite.adapter.test.ts
@@ -952,3 +952,68 @@ describe("SqliteAdapter — getTableColumns with FK mapping", () => {
 		expect(pkCol?.isForeignKey).toBe(false);
 	});
 });
+
+describe("SqliteAdapter.renameTable", () => {
+	let adapter: SqliteAdapter;
+	let statements: string[];
+	const existing = ["users", "orders", 'we"ird'];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		adapter = new SqliteAdapter();
+		statements = [];
+		const db = {
+			prepare: vi.fn((sql: string) => {
+				const text = String(sql);
+				return {
+					all: vi.fn(() => []),
+					get: vi.fn((...args: unknown[]) => {
+						if (text.includes("sqlite_master") && text.includes("name=?")) {
+							const name = args[0] as string;
+							return existing.includes(name) ? { name } : undefined;
+						}
+						return null;
+					}),
+					run: vi.fn(() => {
+						statements.push(text);
+						return { changes: 1, lastInsertRowid: 1 };
+					}),
+				};
+			}),
+			pragma: vi.fn(),
+			transaction: vi.fn(<T>(fn: (...args: unknown[]) => T) => fn),
+		};
+		mockGetSqliteDb.mockReturnValue(db);
+	});
+
+	it("renames an existing table", async () => {
+		await adapter.renameTable({ db: "main", tableName: "users", newTableName: "members" });
+		expect(statements).toEqual(['ALTER TABLE "users" RENAME TO "members"']);
+	});
+
+	it("escapes double quotes in identifiers", async () => {
+		await adapter.renameTable({ db: "main", tableName: 'we"ird', newTableName: "ok" });
+		expect(statements).toEqual(['ALTER TABLE "we""ird" RENAME TO "ok"']);
+	});
+
+	it("returns 404 when the table does not exist", async () => {
+		await expect(
+			adapter.renameTable({ db: "main", tableName: "ghost", newTableName: "spook" }),
+		).rejects.toMatchObject({ status: 404 });
+		expect(statements).toEqual([]);
+	});
+
+	it("returns 409 when the target table already exists", async () => {
+		await expect(
+			adapter.renameTable({ db: "main", tableName: "users", newTableName: "orders" }),
+		).rejects.toMatchObject({ status: 409 });
+		expect(statements).toEqual([]);
+	});
+
+	it("returns 400 when the new name equals the current name", async () => {
+		await expect(
+			adapter.renameTable({ db: "main", tableName: "users", newTableName: "users" }),
+		).rejects.toMatchObject({ status: 400 });
+		expect(statements).toEqual([]);
+	});
+});

--- a/packages/server/tests/routes/tables.routes.test.ts
+++ b/packages/server/tests/routes/tables.routes.test.ts
@@ -813,6 +813,34 @@ describe("Tables Routes", () => {
 			const json = await res.json();
 			expect(json.error).toBe('Table "products" does not exist');
 		});
+
+		it("should return 503 when database connection fails", async () => {
+			mockDao.renameTable.mockRejectedValue(
+				new Error("connect ECONNREFUSED")
+			);
+
+			const res = await app.request("/api/pg/tables/products/rename?db=testdb", {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ newTableName: "product" }),
+			});
+
+			expect(res.status).toBe(503);
+		});
+
+		it("should return 500 when DAO throws database error", async () => {
+			mockDao.renameTable.mockRejectedValue(
+				new Error("relation already exists")
+			);
+
+			const res = await app.request("/api/pg/tables/products/rename?db=testdb", {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ newTableName: "product" }),
+			});
+
+			expect(res.status).toBe(500);
+		});
 	});
 
 	// ============================================

--- a/packages/server/tests/routes/tables.routes.test.ts
+++ b/packages/server/tests/routes/tables.routes.test.ts
@@ -11,6 +11,7 @@ const mockDao = vi.hoisted(() => ({
 	getTablesList: vi.fn(),
 	createTable: vi.fn(),
 	deleteTable: vi.fn(),
+	renameTable: vi.fn(),
 	getTableSchema: vi.fn(),
 	getTableColumns: vi.fn(),
 	addColumn: vi.fn(),
@@ -671,7 +672,7 @@ describe("Tables Routes", () => {
 		};
 
 		it("should add a column and return 200", async () => {
-			mockDao.addColumn.mockResolvedValue();
+			mockDao.addColumn.mockResolvedValue(undefined);
 
 			const res = await app.request("/api/pg/tables/users/columns?db=testdb", {
 				method: "POST",
@@ -755,11 +756,71 @@ describe("Tables Routes", () => {
 	});
 
 	// ============================================
+	// PATCH /tables/:tableName/rename
+	// ============================================
+	describe("PATCH /pg/tables/:tableName/rename", () => {
+		it("should rename a table and return 200", async () => {
+			mockDao.renameTable.mockResolvedValue(undefined);
+
+			const res = await app.request("/api/pg/tables/products/rename?db=testdb", {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ newTableName: "product" }),
+			});
+
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			expect(json.data).toBe('Table "products" renamed to "product"');
+			expect(mockDao.renameTable).toHaveBeenCalledWith({
+				tableName: "products",
+				db: "testdb",
+				newTableName: "product",
+			});
+		});
+
+		it("should return 400 when db query param is missing", async () => {
+			const res = await app.request("/api/pg/tables/products/rename", {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ newTableName: "product" }),
+			});
+
+			expect(res.status).toBe(400);
+		});
+
+		it("should return 400 when newTableName is missing", async () => {
+			const res = await app.request("/api/pg/tables/products/rename?db=testdb", {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({}),
+			});
+
+			expect(res.status).toBe(400);
+		});
+
+		it("should propagate error from adapter", async () => {
+			mockDao.renameTable.mockRejectedValue(
+				new HTTPException(404, { message: 'Table "products" does not exist' }),
+			);
+
+			const res = await app.request("/api/pg/tables/products/rename?db=testdb", {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ newTableName: "product" }),
+			});
+
+			expect(res.status).toBe(404);
+			const json = await res.json();
+			expect(json.error).toBe('Table "products" does not exist');
+		});
+	});
+
+	// ============================================
 	// PATCH /tables/:tableName/columns/:columnName/rename
 	// ============================================
 	describe("PATCH /pg/tables/:tableName/columns/:columnName/rename", () => {
 		it("should rename a column and return 200", async () => {
-			mockDao.renameColumn.mockResolvedValue();
+			mockDao.renameColumn.mockResolvedValue(undefined);
 
 			const res = await app.request("/api/pg/tables/users/columns/email/rename?db=testdb", {
 				method: "PATCH",
@@ -858,7 +919,7 @@ describe("Tables Routes", () => {
 		};
 
 		it("should alter a column and return 200", async () => {
-			mockDao.alterColumn.mockResolvedValue();
+			mockDao.alterColumn.mockResolvedValue(undefined);
 
 			const res = await app.request("/api/pg/tables/users/columns/email?db=testdb", {
 				method: "PATCH",

--- a/packages/server/tests/utils/create-server.test.ts
+++ b/packages/server/tests/utils/create-server.test.ts
@@ -168,6 +168,7 @@ describe("createServer", () => {
 			expect(methods).toContain("GET");
 			expect(methods).toContain("POST");
 			expect(methods).toContain("PUT");
+			expect(methods).toContain("PATCH");
 			expect(methods).toContain("DELETE");
 			expect(methods).toContain("OPTIONS");
 		});

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -20,6 +20,7 @@ export * from "./export-table.types.js";
 export * from "./key-browser.types.js";
 export * from "./rate-limit-response.type.js";
 export * from "./rename-column.types.js";
+export * from "./rename-table.types.js";
 export * from "./table-data.types.js"; // done
 export * from "./table-info.type.js"; // done
 export * from "./table-schema.types.js"; // done

--- a/packages/shared/src/types/rename-table.types.ts
+++ b/packages/shared/src/types/rename-table.types.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { databaseSchema, tableNameSchema } from "./database.types";
+
+export const renameTableSchema = z.object({
+	// Trimmed server-side so whitespace-only names are rejected even if a
+	// client skips the frontend trim (matches the sidebar dialog behavior).
+	newTableName: z
+		.string("New table name is required")
+		.trim()
+		.min(1, "New table name is required"),
+});
+
+export type RenameTableSchemaType = z.infer<typeof renameTableSchema>;
+
+export const renameTableParamSchema = tableNameSchema;
+
+export type RenameTableParamSchemaType = z.infer<typeof renameTableParamSchema>;
+
+export const renameTableParamsSchema = z.object({
+	db: databaseSchema.shape.db,
+	tableName: tableNameSchema.shape.tableName,
+	newTableName: renameTableSchema.shape.newTableName,
+});
+
+export type RenameTableParamsSchemaType = z.infer<typeof renameTableParamsSchema>;

--- a/packages/web/src/components/sidebar/sidebar-list-tables-menu.tsx
+++ b/packages/web/src/components/sidebar/sidebar-list-tables-menu.tsx
@@ -19,7 +19,9 @@ import {
 	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 } from "@db-studio/ui/dropdown-menu";
-import { useNavigate } from "@tanstack/react-router";
+import { Input } from "@db-studio/ui/input";
+import { Label } from "@db-studio/ui/label";
+import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
 import {
 	ClipboardCopy,
 	Download,
@@ -27,20 +29,49 @@ import {
 	FileCode,
 	Pencil,
 	Trash2,
+	Type,
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { useDeleteTable, useExportFile } from "@/features/tables";
+import { useDeleteTable, useExportFile, useRenameTable } from "@/features/tables";
 import { useCopyTableSchema } from "@/hooks/use-copy-table-schema";
 
 export const SidebarListTablesMenu = ({ tableName }: { tableName: string }) => {
 	const navigate = useNavigate();
+	const params = useParams({ strict: false });
+	const { pathname } = useLocation();
 	const { copyTableSchema, isCopyingSchema } = useCopyTableSchema();
 	const { exportFile, isExportingFile } = useExportFile();
 	const { deleteTable, forceDeleteTable, isDeletingTable } = useDeleteTable();
+	const { renameTable, isRenamingTable } = useRenameTable({ tableName });
 	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 	const [isForceDeleteDialogOpen, setIsForceDeleteDialogOpen] = useState(false);
+	const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
+	const [newTableName, setNewTableName] = useState(tableName);
 	const [relatedRecords, setRelatedRecords] = useState<RelatedRecord[]>([]);
+
+	const handleRenameDialogChange = (open: boolean) => {
+		setIsRenameDialogOpen(open);
+		if (open) {
+			setNewTableName(tableName);
+		}
+	};
+
+	const handleRename = async () => {
+		const trimmed = newTableName.trim();
+		if (!trimmed || trimmed === tableName) return;
+		try {
+			await renameTable({ newTableName: trimmed });
+			handleRenameDialogChange(false);
+			const activeTable = (params as { table?: string }).table;
+			if (activeTable === tableName) {
+				const basePath = pathname.startsWith("/schema") ? "/schema/$table" : "/table/$table";
+				navigate({ to: basePath, params: { table: trimmed } });
+			}
+		} catch {
+			// Error notification handled by toast.promise in useRenameTable
+		}
+	};
 
 	const handleCopyName = () => {
 		navigator.clipboard.writeText(tableName);
@@ -99,6 +130,10 @@ export const SidebarListTablesMenu = ({ tableName }: { tableName: string }) => {
 							Copy table schema
 						</DropdownMenuItem>
 						<DropdownMenuSeparator />
+						<DropdownMenuItem onClick={() => handleRenameDialogChange(true)}>
+							<Type className="size-4" />
+							Rename table
+						</DropdownMenuItem>
 						<DropdownMenuItem
 							onClick={() =>
 								navigate({
@@ -148,6 +183,16 @@ export const SidebarListTablesMenu = ({ tableName }: { tableName: string }) => {
 				</DropdownMenuContent>
 			</DropdownMenu>
 
+			<RenameTableDialog
+				tableName={tableName}
+				newTableName={newTableName}
+				setNewTableName={setNewTableName}
+				isOpen={isRenameDialogOpen}
+				onOpenChange={handleRenameDialogChange}
+				onRename={handleRename}
+				isRenaming={isRenamingTable}
+			/>
+
 			<DeleteTableDialog
 				isOpen={isDeleteDialogOpen}
 				onOpenChange={setIsDeleteDialogOpen}
@@ -166,6 +211,88 @@ export const SidebarListTablesMenu = ({ tableName }: { tableName: string }) => {
 				isDeleting={isDeletingTable}
 			/>
 		</>
+	);
+};
+
+const RenameTableDialog = ({
+	tableName,
+	newTableName,
+	setNewTableName,
+	isOpen,
+	onOpenChange,
+	onRename,
+	isRenaming,
+}: {
+	tableName: string;
+	newTableName: string;
+	setNewTableName: (value: string) => void;
+	isOpen: boolean;
+	onOpenChange: (open: boolean) => void;
+	onRename: () => void;
+	isRenaming: boolean;
+}) => {
+	const trimmed = newTableName.trim();
+	const isDisabled = !trimmed || trimmed === tableName;
+
+	return (
+		<Dialog
+			open={isOpen}
+			onOpenChange={onOpenChange}
+		>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle>Rename Table</DialogTitle>
+					<DialogDescription>
+						Update the table name while keeping all data and schema unchanged.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4">
+					<div className="space-y-2">
+						<Label htmlFor="current-table-name">Current name</Label>
+						<Input
+							id="current-table-name"
+							value={tableName}
+							readOnly
+							disabled
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="new-table-name">New name</Label>
+						<Input
+							id="new-table-name"
+							value={newTableName}
+							onChange={(e) => setNewTableName(e.target.value)}
+							placeholder="table_name"
+							autoFocus
+							disabled={isRenaming}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" && !isDisabled && !isRenaming) {
+									onRename();
+								}
+							}}
+						/>
+					</div>
+				</div>
+
+				<DialogFooter className="gap-2">
+					<Button
+						variant="outline"
+						onClick={() => onOpenChange(false)}
+						disabled={isRenaming}
+					>
+						Cancel
+					</Button>
+					<Button
+						onClick={onRename}
+						disabled={isDisabled || isRenaming}
+					>
+						{isRenaming ? "Renaming..." : "Rename Table"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
 	);
 };
 

--- a/packages/web/src/features/tables/hooks/use-rename-table.ts
+++ b/packages/web/src/features/tables/hooks/use-rename-table.ts
@@ -1,0 +1,66 @@
+import type { RenameTableSchemaType } from "@db-studio/shared/types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { renameTable as renameTableRequest } from "@/shared/api";
+import { tableKeys } from "@/shared/query/keys";
+import { useDatabaseStore } from "@/stores/database.store";
+import { CONSTANTS } from "@/utils/constants";
+
+type MutationError = Error & {
+	details?: unknown;
+};
+
+export const useRenameTable = ({ tableName }: { tableName: string }) => {
+	const queryClient = useQueryClient();
+	const { selectedDatabase } = useDatabaseStore();
+
+	const { mutateAsync: renameTableMutation, isPending: isRenamingTable } = useMutation<
+		string,
+		MutationError,
+		RenameTableSchemaType
+	>({
+		mutationFn: async (data) => {
+			const res = await renameTableRequest({
+				tableName,
+				data,
+				db: selectedDatabase,
+			});
+			return res.data.data;
+		},
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({
+				queryKey: tableKeys.lists(),
+			});
+			await queryClient.removeQueries({
+				queryKey: [CONSTANTS.CACHE_KEYS.TABLE_DATA, tableName],
+			});
+			await queryClient.removeQueries({
+				queryKey: [CONSTANTS.CACHE_KEYS.TABLE_COLUMNS, tableName],
+			});
+		},
+	});
+
+	const renameTable = async (
+		data: RenameTableSchemaType,
+		options?: {
+			onSuccess?: () => void;
+			onError?: (error: MutationError) => void;
+		},
+	) => {
+		const promise = renameTableMutation(data, options);
+		toast.promise(promise, {
+			loading: "Renaming table...",
+			success: (message) => message || "Table renamed successfully",
+			error: (error: MutationError) =>
+				(typeof error.details === "string" && error.details) ||
+				error.message ||
+				"Failed to rename table",
+		});
+		return promise;
+	};
+
+	return {
+		renameTable,
+		isRenamingTable,
+	};
+};

--- a/packages/web/src/features/tables/index.ts
+++ b/packages/web/src/features/tables/index.ts
@@ -1,5 +1,6 @@
 export { useDeleteTable } from "./hooks/use-delete-table";
 export { useExportFile } from "./hooks/use-export-file";
+export { useRenameTable } from "./hooks/use-rename-table";
 export { useTableNavigation } from "./hooks/use-table-navigation";
 export { useTablesList } from "./hooks/use-tables-list";
 export { TableScreen } from "./screens/table-screen";

--- a/packages/web/src/shared/api/tables.ts
+++ b/packages/web/src/shared/api/tables.ts
@@ -8,6 +8,7 @@ import type {
 	DeleteTableResult,
 	FormatType,
 	RenameColumnSchemaType,
+	RenameTableSchemaType,
 	TableDataResultSchemaType,
 	TableInfoSchemaType,
 	TableSchemaResult,
@@ -75,6 +76,19 @@ export const deleteTable = ({
 }) =>
 	api.delete<BaseResponse<DeleteTableResult>>(`/tables/${encodeURIComponent(tableName)}`, {
 		params: { db: db ?? "", cascade: cascade ? "true" : "false" },
+	});
+
+export const renameTable = ({
+	tableName,
+	data,
+	db,
+}: {
+	tableName: string;
+	data: RenameTableSchemaType;
+	db?: string | null;
+}) =>
+	api.patch<BaseResponse<string>>(`/tables/${encodeURIComponent(tableName)}/rename`, data, {
+		params: { db: db ?? "" },
 	});
 
 export const addColumn = ({


### PR DESCRIPTION
Closes #281.

Adds a **Rename table** action to each table's sidebar menu (above Edit table) with a `RenameTable` dialog matching the design system, backed by `PATCH /:dbType/tables/:tableName/rename`.

Adapter coverage:
- pg — schema-aware `ALTER TABLE "schema"."old" RENAME TO "new"` (resolves non-public schemas)
- mysql — `RENAME TABLE`
- mssql — parameterized `EXEC sp_rename @oldName, @newName`
- sqlite — `ALTER TABLE … RENAME TO …`
- mongodb — driver collection `rename()`
- redis — `400` by design (fixed type-tables)

Security: identifiers escaped per dialect (`""`, backtick doubling, bound params); zod-validated body (`newTableName` trimmed, min 1); CORS preflight allows `PATCH`.

Tests: adapter + route coverage for every database (server suite green).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added table renaming from the table sidebar menu.
  * Added a rename dialog with validation, success and error notifications, and automatic navigation to the renamed table.
  * Added table-renaming API support for supported databases.
  * Added a `PATCH` endpoint for renaming tables.
  * Added safeguards for invalid, missing, unchanged, or duplicate table names.

* **Bug Fixes**
  * Enabled `PATCH` requests in CORS preflight responses.

* **Tests**
  * Added coverage for successful renames and validation, missing-table, and duplicate-name errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->