### PR TITLE
fix(web): give sticky table header an opaque background

### DIFF
--- a/packages/ui/src/data-display/data-grid/data-grid-head.tsx
+++ b/packages/ui/src/data-display/data-grid/data-grid-head.tsx
@@ -20,12 +20,12 @@ export const DataGridHead = <TRow,>({
 	const isAnyColumnResizing = table.getState().columnSizingInfo.isResizingColumn;
 
 	return (
-		<thead className="h-9 grid sticky top-0 z-10">
+		<thead className="h-9 grid sticky top-0 z-10 bg-muted">
 			{table.getHeaderGroups().map((headerGroup) => (
 				<tr
 					key={headerGroup.id}
 					className={cn(
-						"flex w-fit bg-muted/40 border-b border-border items-center text-sm [&_svg]:size-4",
+						"flex w-fit bg-muted border-b border-border items-center text-sm [&_svg]:size-4",
 						isAnyColumnResizing && "pointer-events-none",
 					)}
 				>

--- a/packages/web/src/features/query-runner/components/table-view.tsx
+++ b/packages/web/src/features/query-runner/components/table-view.tsx
@@ -49,7 +49,7 @@ export const TableView = ({ results }: { results: ExecuteQueryResult | null }) =
 			className="relative h-full overflow-auto w-full bg-background text-foreground"
 		>
 			<div
-				className="sticky top-0 z-20 bg-muted/40 border-b border-border"
+				className="sticky top-0 z-20 bg-muted border-b border-border"
 				style={{ width: `${totalTableWidth}px`, minWidth: "100%" }}
 			>
 				{table.getHeaderGroups().map((headerGroup) => (

--- a/packages/web/src/features/records/components/referenced-table.tsx
+++ b/packages/web/src/features/records/components/referenced-table.tsx
@@ -139,7 +139,7 @@ export const ReferencedTable = ({
 				<TableHeader>
 					{table.getHeaderGroups().map((headerGroup) => (
 						<TableRow
-							className="hover:bg-transparent text-xs sticky top-0 right-0 left-0"
+							className="bg-muted hover:bg-muted text-xs sticky top-0 right-0 left-0"
 							key={headerGroup.id}
 						>
 							{headerGroup.headers.map((header) => {

--- a/packages/web/src/features/tables/components/table-head-row.tsx
+++ b/packages/web/src/features/tables/components/table-head-row.tsx
@@ -139,7 +139,7 @@ export const TableHeadRow = ({
 			<tr
 				key={headerGroup.id}
 				className={cn(
-					"flex w-fit bg-muted/40 border-b border-border items-center justify-between text-sm data-[state=open]:bg-accent/40 [&_svg]:size-4",
+					"flex w-fit bg-muted border-b border-border items-center justify-between text-sm data-[state=open]:bg-accent/40 [&_svg]:size-4",
 					isAnyColumnResizing && "pointer-events-none",
 				)}
 			>

--- a/packages/web/src/features/tables/components/table-head.tsx
+++ b/packages/web/src/features/tables/components/table-head.tsx
@@ -17,7 +17,7 @@ export const TableHead = ({
 	virtualPaddingRight,
 }: TableHeadProps) => {
 	return (
-		<thead className="h-9 grid sticky top-0 z-10">
+		<thead className="h-9 grid sticky top-0 z-10 bg-muted">
 			{table.getHeaderGroups().map((headerGroup) => (
 				<TableHeadRow
 					columnVirtualizer={columnVirtualizer}


### PR DESCRIPTION
Closes #283.

Fixes the sticky table header showing row data through it when scrolling. The header row used a translucent bg-muted/40 with a transparent thead, so body text stayed visible behind the column names.

Now the thead and header row use a solid theme-aware bg-muted, so rows slide underneath cleanly in both dark and light mode. I've applied the same fix to the shared data grid, the query runner result header, and the referenced-table header since they had the same pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated table and data grid headers with a consistent muted background.
  - Improved the appearance of sticky headers across query results and table views.
  - Ensured header backgrounds remain visible when hovering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->