### PR TITLE
feat(tables): add an editable row details sheet

### DIFF
--- a/packages/web/src/features/records/components/add-record-field.tsx
+++ b/packages/web/src/features/records/components/add-record-field.tsx
@@ -43,7 +43,8 @@ export const AddRecordField = ({
 	isForeignKey,
 	referencedTable,
 	referencedColumn,
-}: ColumnInfoSchemaType) => {
+	hideLabel = false,
+}: ColumnInfoSchemaType & { hideLabel?: boolean }) => {
 	const [, setReferencedActiveTable] = useQueryState(
 		CONSTANTS.REFERENCED_TABLE_STATE_KEYS.ACTIVE_TABLE,
 	);
@@ -494,15 +495,24 @@ export const AddRecordField = ({
 			key={columnName}
 			control={control}
 			name={columnName}
-			render={({ field }) => (
-				<div className="grid grid-cols-3 gap-4">
-					<div className="col-span-1 flex flex-col gap-1">
-						<Label htmlFor={columnName}>{columnName}</Label>
-						<span className="text-xs text-muted-foreground">{dataTypeLabel}</span>
+			render={({ field }) =>
+				hideLabel ? (
+					<div
+						role="group"
+						aria-label={columnName}
+					>
+						{renderInputField(field)}
 					</div>
-					<div className="col-span-2 w-full">{renderInputField(field)}</div>
-				</div>
-			)}
+				) : (
+					<div className="grid grid-cols-3 gap-4">
+						<div className="col-span-1 flex flex-col gap-1">
+							<Label htmlFor={columnName}>{columnName}</Label>
+							<span className="text-xs text-muted-foreground">{dataTypeLabel}</span>
+						</div>
+						<div className="col-span-2 w-full">{renderInputField(field)}</div>
+					</div>
+				)
+			}
 		/>
 	);
 };

--- a/packages/web/src/features/records/components/add-record-field.tsx
+++ b/packages/web/src/features/records/components/add-record-field.tsx
@@ -57,6 +57,9 @@ export const AddRecordField = ({
 			...field,
 			value: field.value ?? "",
 		};
+		// Without a visible <Label>, name each primary control directly. The
+		// visible-label path stays associated through htmlFor and is untouched.
+		const controlName = hideLabel ? columnName : undefined;
 
 		if (isForeignKey) {
 			return (
@@ -64,6 +67,7 @@ export const AddRecordField = ({
 					<div className="flex">
 						<Input
 							id={columnName}
+							aria-label={controlName}
 							placeholder={columnDefault ?? ""}
 							className="-me-px flex-1 rounded-e-none shadow-none focus-visible:z-10"
 							{...safeField}
@@ -129,6 +133,7 @@ export const AddRecordField = ({
 			return (
 				<Input
 					id={columnName}
+					aria-label={controlName}
 					type="number"
 					placeholder={columnDefault ?? "0"}
 					{...safeField}
@@ -142,7 +147,10 @@ export const AddRecordField = ({
 					value={field.value}
 					onValueChange={(value) => field.onChange(value)}
 				>
-					<SelectTrigger className="w-full">
+					<SelectTrigger
+						aria-label={controlName}
+						className="w-full"
+					>
 						<SelectValue placeholder={columnDefault ?? "true"} />
 					</SelectTrigger>
 					<SelectContent>
@@ -157,6 +165,7 @@ export const AddRecordField = ({
 			return (
 				<Textarea
 					id={columnName}
+					aria-label={controlName}
 					placeholder={columnDefault ?? ""}
 					rows={4}
 					{...safeField}
@@ -168,6 +177,7 @@ export const AddRecordField = ({
 			return (
 				<Textarea
 					id={columnName}
+					aria-label={controlName}
 					placeholder={columnDefault ?? '{"key": "value"}'}
 					rows={6}
 					{...safeField}
@@ -343,6 +353,7 @@ export const AddRecordField = ({
 				<div className="flex">
 					<Input
 						id={columnName}
+						aria-label={controlName}
 						type="text"
 						placeholder={columnDefault ?? ""}
 						pattern="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
@@ -379,6 +390,7 @@ export const AddRecordField = ({
 			return (
 				<Textarea
 					id={columnName}
+					aria-label={controlName}
 					placeholder={columnDefault ?? '["item1", "item2"]'}
 					rows={3}
 					{...safeField}
@@ -393,7 +405,10 @@ export const AddRecordField = ({
 						value={field.value}
 						onValueChange={(value) => field.onChange(value)}
 					>
-						<SelectTrigger className="w-full">
+						<SelectTrigger
+							aria-label={controlName}
+							className="w-full"
+						>
 							<SelectValue placeholder={columnDefault ?? "Select a value"} />
 						</SelectTrigger>
 						<SelectContent>
@@ -412,6 +427,7 @@ export const AddRecordField = ({
 			return (
 				<Input
 					id={columnName}
+					aria-label={controlName}
 					placeholder={columnDefault ?? ""}
 					{...safeField}
 				/>
@@ -422,6 +438,7 @@ export const AddRecordField = ({
 			return (
 				<Input
 					id={columnName}
+					aria-label={controlName}
 					type="text"
 					placeholder={columnDefault ?? "1 day"}
 					{...safeField}
@@ -433,6 +450,7 @@ export const AddRecordField = ({
 			return (
 				<Input
 					id={columnName}
+					aria-label={controlName}
 					type="file"
 					{...safeField}
 				/>
@@ -448,6 +466,7 @@ export const AddRecordField = ({
 			return (
 				<Input
 					id={columnName}
+					aria-label={controlName}
 					type="text"
 					placeholder={
 						dataTypeLabel === "inet"
@@ -467,6 +486,7 @@ export const AddRecordField = ({
 			return (
 				<Input
 					id={columnName}
+					aria-label={controlName}
 					type="text"
 					placeholder={
 						dataTypeLabel === "point"
@@ -483,6 +503,7 @@ export const AddRecordField = ({
 		return (
 			<Input
 				id={columnName}
+				aria-label={controlName}
 				type="text"
 				placeholder={columnDefault ?? ""}
 				{...safeField}

--- a/packages/web/src/features/records/index.ts
+++ b/packages/web/src/features/records/index.ts
@@ -1,3 +1,4 @@
+export { AddRecordField } from "./components/add-record-field";
 export { AddRecordForm } from "./components/add-record-form";
 export { BulkInsertCsvSheet } from "./components/bulk-insert-csv-sheet";
 export { BulkInsertExcelSheet } from "./components/bulk-insert-excel-sheet";

--- a/packages/web/src/features/tables/components/row-details-sheet.test.tsx
+++ b/packages/web/src/features/tables/components/row-details-sheet.test.tsx
@@ -239,6 +239,22 @@ describe("RowDetailsSheet", () => {
 		});
 	});
 
+	it("keeps the sheet open with edits intact when saving fails", async () => {
+		fixtures.updateRecord.mockRejectedValueOnce(new Error("boom"));
+		renderSheet();
+
+		const nameInput = screen.getByDisplayValue("Ada");
+		await user.clear(nameInput);
+		await user.type(nameInput, "Grace");
+		await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+		await waitFor(() => {
+			expect(fixtures.updateRecord).toHaveBeenCalledTimes(1);
+		});
+		expect(screen.getByText("Row details")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("Grace")).toBeInTheDocument();
+	});
+
 	it("asks for confirmation before changing the primary key", async () => {
 		fixtures.cols = [
 			{

--- a/packages/web/src/features/tables/components/row-details-sheet.test.tsx
+++ b/packages/web/src/features/tables/components/row-details-sheet.test.tsx
@@ -1,0 +1,472 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent, { type UserEvent } from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useOverlayStore } from "@/stores/overlay.store";
+import { useRowDetailsStore } from "../stores/row-details.store";
+import { RowDetailsSheet } from "./row-details-sheet";
+
+const makeCols = () => [
+	{
+		columnName: "id",
+		dataType: "number",
+		dataTypeLabel: "int",
+		isNullable: false,
+		columnDefault: "nextval('users_id_seq'::regclass)",
+		isPrimaryKey: true,
+		isForeignKey: false,
+		referencedTable: null,
+		referencedColumn: null,
+		enumValues: null,
+	},
+	{
+		columnName: "name",
+		dataType: "text",
+		dataTypeLabel: "text",
+		isNullable: true,
+		columnDefault: null,
+		isPrimaryKey: false,
+		isForeignKey: false,
+		referencedTable: null,
+		referencedColumn: null,
+		enumValues: null,
+	},
+	{
+		columnName: "age",
+		dataType: "number",
+		dataTypeLabel: "int",
+		isNullable: true,
+		columnDefault: null,
+		isPrimaryKey: false,
+		isForeignKey: false,
+		referencedTable: null,
+		referencedColumn: null,
+		enumValues: null,
+	},
+	{
+		columnName: "is_active",
+		dataType: "boolean",
+		dataTypeLabel: "boolean",
+		isNullable: true,
+		columnDefault: "true",
+		isPrimaryKey: false,
+		isForeignKey: false,
+		referencedTable: null,
+		referencedColumn: null,
+		enumValues: null,
+	},
+	{
+		columnName: "role",
+		dataType: "enum",
+		dataTypeLabel: "enum",
+		isNullable: true,
+		columnDefault: null,
+		isPrimaryKey: false,
+		isForeignKey: false,
+		referencedTable: null,
+		referencedColumn: null,
+		enumValues: ["admin", "user"],
+	},
+	{
+		columnName: "meta",
+		dataType: "json",
+		dataTypeLabel: "jsonb",
+		isNullable: true,
+		columnDefault: null,
+		isPrimaryKey: false,
+		isForeignKey: false,
+		referencedTable: null,
+		referencedColumn: null,
+		enumValues: null,
+	},
+	{
+		columnName: "created",
+		dataType: "date",
+		dataTypeLabel: "date",
+		isNullable: true,
+		columnDefault: null,
+		isPrimaryKey: false,
+		isForeignKey: false,
+		referencedTable: null,
+		referencedColumn: null,
+		enumValues: null,
+	},
+];
+
+const makeRows = () => [
+	{
+		id: 1,
+		name: "Ada",
+		age: 36,
+		is_active: true,
+		role: "admin",
+		meta: { a: 1 },
+		created: "2024-01-02",
+	},
+	{ id: 2, name: "Bob", age: 41, is_active: false, role: "user", meta: null, created: null },
+	{
+		id: 3,
+		name: "Cy",
+		age: 29,
+		is_active: true,
+		role: "user",
+		meta: {},
+		created: "2024-03-04",
+	},
+];
+
+const fixtures = vi.hoisted(() => ({
+	cols: [] as ReturnType<typeof makeCols>,
+	rows: [] as ReturnType<typeof makeRows>,
+	updateRecord: vi.fn(async () => "Updated 1 record"),
+	deleteCells: vi.fn(async () => ({ deletedCount: 1 })),
+	copyText: vi.fn(async (_value: string) => {}),
+}));
+
+vi.mock("./row-details-utils", async (importOriginal) => {
+	const mod = await importOriginal<typeof import("./row-details-utils")>();
+	return { ...mod, copyTextToClipboard: (...args: unknown[]) => fixtures.copyText(...args) };
+});
+
+vi.mock("@/features/schema", () => ({
+	useTableCols: () => ({ tableCols: fixtures.cols, isLoadingTableCols: false }),
+}));
+vi.mock("@/features/tables/hooks/use-update-record", () => ({
+	useUpdateRecord: () => ({
+		updateRecord: fixtures.updateRecord,
+		isUpdatingRecord: false,
+	}),
+}));
+vi.mock("@/features/tables/hooks/use-delete-cell", () => ({
+	useDeleteCells: () => ({
+		deleteCells: fixtures.deleteCells,
+		isDeletingCells: false,
+	}),
+}));
+vi.mock("@/features/records", async (importOriginal) => {
+	const mod = await importOriginal<typeof import("@/features/records")>();
+	return { ...mod, RecordReferenceSheet: () => null };
+});
+vi.mock("nuqs", () => ({
+	useQueryState: () => [null, vi.fn()],
+}));
+
+const renderSheet = (rowIndex = 0) => {
+	useOverlayStore.getState().openOverlay("tables.row-details");
+	useRowDetailsStore.getState().setRowDetails("users", rowIndex);
+	render(
+		<RowDetailsSheet
+			tableName="users"
+			rows={fixtures.rows}
+		/>,
+	);
+};
+
+const sheetDialog = () => {
+	const title = screen.getByText("Row details");
+	const dialog = title.closest("[role='dialog']");
+	expect(dialog).not.toBeNull();
+	return dialog as HTMLElement;
+};
+
+describe("RowDetailsSheet", () => {
+	let user: UserEvent;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		fixtures.cols = makeCols();
+		fixtures.rows = makeRows();
+		useOverlayStore.setState({ openOverlays: [] });
+		useRowDetailsStore.setState({ tableName: null, rowIndex: null });
+		user = userEvent.setup();
+	});
+
+	it("shows every field with formatted values and type-appropriate controls", () => {
+		renderSheet();
+
+		expect(screen.getByDisplayValue("Ada")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("36")).toBeInTheDocument();
+		expect(screen.getByDisplayValue('{"a":1}')).toBeInTheDocument();
+		// Boolean, enum, and date controls keep an accessible group label.
+		expect(screen.getByRole("group", { name: "is_active" })).toBeInTheDocument();
+		expect(screen.getByRole("group", { name: "role" })).toBeInTheDocument();
+		expect(screen.getByRole("group", { name: "created" })).toBeInTheDocument();
+	});
+
+	it("renders generated primary keys read-only", () => {
+		renderSheet();
+
+		expect(screen.getByText("1")).toBeInTheDocument();
+		expect(screen.queryByDisplayValue("1")).not.toBeInTheDocument();
+	});
+
+	it("copies an individual value to the clipboard", async () => {
+		renderSheet();
+
+		const copyButtons = screen.getAllByLabelText("Copy value");
+		expect(copyButtons.length).toBeGreaterThan(1);
+		await user.click(copyButtons[1]);
+
+		expect(fixtures.copyText).toHaveBeenCalledWith("Ada");
+		expect(await screen.findByLabelText("Copied")).toBeInTheDocument();
+	});
+
+	it("saves all dirty fields through one update call", async () => {
+		renderSheet();
+
+		const saveButton = screen.getByRole("button", { name: "Save changes" });
+		expect(saveButton).toBeDisabled();
+
+		const nameInput = screen.getByDisplayValue("Ada");
+		await user.clear(nameInput);
+		await user.type(nameInput, "Grace");
+		expect(saveButton).not.toBeDisabled();
+
+		await user.click(saveButton);
+
+		expect(fixtures.updateRecord).toHaveBeenCalledTimes(1);
+		expect(fixtures.updateRecord).toHaveBeenCalledWith({
+			rowData: fixtures.rows[0],
+			updates: [{ columnName: "name", value: "Grace" }],
+			primaryKey: "id",
+		});
+		await waitFor(() => {
+			expect(screen.queryByText("Row details")).not.toBeInTheDocument();
+		});
+	});
+
+	it("asks for confirmation before changing the primary key", async () => {
+		fixtures.cols = [
+			{
+				columnName: "code",
+				dataType: "text",
+				dataTypeLabel: "text",
+				isNullable: false,
+				columnDefault: null,
+				isPrimaryKey: true,
+				isForeignKey: false,
+				referencedTable: null,
+				referencedColumn: null,
+				enumValues: null,
+			},
+			{
+				columnName: "name",
+				dataType: "text",
+				dataTypeLabel: "text",
+				isNullable: true,
+				columnDefault: null,
+				isPrimaryKey: false,
+				isForeignKey: false,
+				referencedTable: null,
+				referencedColumn: null,
+				enumValues: null,
+			},
+		];
+		fixtures.rows = [{ code: "A1", name: "Ada" }];
+		renderSheet();
+
+		const codeInput = screen.getByDisplayValue("A1");
+		await user.clear(codeInput);
+		await user.type(codeInput, "A2");
+		await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+		expect(await screen.findByText("Change the primary key?")).toBeInTheDocument();
+		expect(fixtures.updateRecord).not.toHaveBeenCalled();
+
+		const dialog = screen.getByText("Change the primary key?").closest("[role='alertdialog']");
+		await user.click(
+			within(dialog as HTMLElement).getByRole("button", { name: "Change primary key" }),
+		);
+
+		expect(fixtures.updateRecord).toHaveBeenCalledWith({
+			rowData: fixtures.rows[0],
+			updates: [{ columnName: "code", value: "A2" }],
+			primaryKey: "code",
+		});
+	});
+
+	it("protects unsaved changes when closing", async () => {
+		renderSheet();
+
+		const nameInput = screen.getByDisplayValue("Ada");
+		await user.clear(nameInput);
+		await user.type(nameInput, "Grace");
+
+		const closeButtons = screen.getAllByRole("button", { name: "Close" });
+		const closeButton = closeButtons.find((button) => button.textContent === "Close");
+		expect(closeButton).toBeDefined();
+		await user.click(closeButton as HTMLElement);
+		expect(await screen.findByText("Discard unsaved changes?")).toBeInTheDocument();
+		expect(screen.getByText("Row details")).toBeInTheDocument();
+
+		const dialog = screen
+			.getByText("Discard unsaved changes?")
+			.closest("[role='alertdialog']");
+		await user.click(
+			within(dialog as HTMLElement).getByRole("button", { name: "Discard changes" }),
+		);
+		await waitFor(() => {
+			expect(screen.queryByText("Row details")).not.toBeInTheDocument();
+		});
+	});
+
+	it("deletes the record behind a destructive confirmation", async () => {
+		renderSheet();
+
+		await user.click(screen.getByRole("button", { name: "Delete" }));
+		expect(await screen.findByText("Delete record")).toBeInTheDocument();
+
+		const dialog = screen.getByText("Delete record").closest("[role='alertdialog']");
+		await user.click(within(dialog as HTMLElement).getByRole("button", { name: "Delete" }));
+
+		expect(fixtures.deleteCells).toHaveBeenCalledWith([fixtures.rows[0]]);
+		await waitFor(() => {
+			expect(screen.queryByText("Row details")).not.toBeInTheDocument();
+		});
+	});
+
+	it("disables deletion and saving for tables without record identity", async () => {
+		fixtures.cols = fixtures.cols.filter((col) => !col.isPrimaryKey);
+		renderSheet();
+
+		expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
+
+		const nameInput = screen.getByDisplayValue("Ada");
+		await user.clear(nameInput);
+		await user.type(nameInput, "Grace");
+		expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
+	});
+
+	it("navigates between rows with chevrons and boundary states", async () => {
+		renderSheet(0);
+
+		expect(screen.getByRole("button", { name: "Previous row" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Next row" })).not.toBeDisabled();
+
+		await user.click(screen.getByRole("button", { name: "Next row" }));
+		expect(await screen.findByDisplayValue("Bob")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Next row" }));
+		expect(await screen.findByDisplayValue("Cy")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Next row" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Previous row" })).not.toBeDisabled();
+	});
+
+	it("navigates with the keyboard outside editors", async () => {
+		renderSheet(0);
+		sheetDialog();
+
+		await user.keyboard("{ArrowDown}");
+		expect(await screen.findByDisplayValue("Bob")).toBeInTheDocument();
+
+		await user.keyboard("{ArrowUp}");
+		expect(await screen.findByDisplayValue("Ada")).toBeInTheDocument();
+	});
+
+	it("cancels the primary key change without saving", async () => {
+		fixtures.cols = [
+			{
+				columnName: "code",
+				dataType: "text",
+				dataTypeLabel: "text",
+				isNullable: false,
+				columnDefault: null,
+				isPrimaryKey: true,
+				isForeignKey: false,
+				referencedTable: null,
+				referencedColumn: null,
+				enumValues: null,
+			},
+		];
+		fixtures.rows = [{ code: "A1" }];
+		renderSheet();
+
+		const codeInput = screen.getByDisplayValue("A1");
+		await user.clear(codeInput);
+		await user.type(codeInput, "A2");
+		await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+		expect(await screen.findByText("Change the primary key?")).toBeInTheDocument();
+		const dialog = screen.getByText("Change the primary key?").closest("[role='alertdialog']");
+		await user.click(within(dialog as HTMLElement).getByRole("button", { name: "Cancel" }));
+
+		expect(fixtures.updateRecord).not.toHaveBeenCalled();
+		expect(screen.queryByText("Change the primary key?")).not.toBeInTheDocument();
+		expect(screen.getByText("Row details")).toBeInTheDocument();
+	});
+
+	it("opens the reference picker for foreign keys", async () => {
+		fixtures.cols = [
+			{
+				columnName: "team_id",
+				dataType: "number",
+				dataTypeLabel: "int",
+				isNullable: true,
+				columnDefault: null,
+				isPrimaryKey: false,
+				isForeignKey: true,
+				referencedTable: "teams",
+				referencedColumn: "id",
+				enumValues: null,
+			},
+		];
+		fixtures.rows = [{ team_id: 7 }];
+		renderSheet();
+
+		await user.click(screen.getByRole("button", { name: "Go to table" }));
+
+		expect(useOverlayStore.getState().openOverlays).toContain("records.record-reference");
+	});
+
+	it("asks before dropping a dirty row that falls off the page", async () => {
+		useOverlayStore.getState().openOverlay("tables.row-details");
+		useRowDetailsStore.getState().setRowDetails("users", 2);
+		const { rerender } = render(
+			<RowDetailsSheet
+				tableName="users"
+				rows={fixtures.rows}
+			/>,
+		);
+		expect(await screen.findByDisplayValue("Cy")).toBeInTheDocument();
+
+		const nameInput = screen.getByDisplayValue("Cy");
+		await user.clear(nameInput);
+		await user.type(nameInput, "Cyll");
+
+		rerender(
+			<RowDetailsSheet
+				tableName="users"
+				rows={fixtures.rows.slice(0, 1)}
+			/>,
+		);
+		expect(await screen.findByText("Discard unsaved changes?")).toBeInTheDocument();
+
+		const dialog = screen
+			.getByText("Discard unsaved changes?")
+			.closest("[role='alertdialog']");
+		await user.click(
+			within(dialog as HTMLElement).getByRole("button", { name: "Discard changes" }),
+		);
+		await waitFor(() => {
+			expect(screen.queryByText("Row details")).not.toBeInTheDocument();
+		});
+	});
+
+	it("asks before navigating away with dirty fields", async () => {
+		renderSheet(0);
+
+		const nameInput = screen.getByDisplayValue("Ada");
+		await user.clear(nameInput);
+		await user.type(nameInput, "Grace");
+
+		await user.click(screen.getByRole("button", { name: "Next row" }));
+		expect(await screen.findByText("Discard unsaved changes?")).toBeInTheDocument();
+
+		const dialog = screen
+			.getByText("Discard unsaved changes?")
+			.closest("[role='alertdialog']");
+		await user.click(
+			within(dialog as HTMLElement).getByRole("button", { name: "Discard changes" }),
+		);
+		expect(await screen.findByDisplayValue("Bob")).toBeInTheDocument();
+	});
+});

--- a/packages/web/src/features/tables/components/row-details-sheet.test.tsx
+++ b/packages/web/src/features/tables/components/row-details-sheet.test.tsx
@@ -490,4 +490,81 @@ describe("RowDetailsSheet", () => {
 		);
 		expect(await screen.findByDisplayValue("Bob")).toBeInTheDocument();
 	});
+
+	it("resets all fields when untouched draft receives refreshed row data", () => {
+		useOverlayStore.getState().openOverlay("tables.row-details");
+		useRowDetailsStore.getState().setRowDetails("users", 0);
+		const { rerender } = render(
+			<RowDetailsSheet
+				tableName="users"
+				rows={fixtures.rows}
+			/>,
+		);
+
+		expect(screen.getByDisplayValue("Ada")).toBeInTheDocument();
+
+		const updatedRows = makeRows();
+		updatedRows[0] = { ...updatedRows[0], name: "Ada Lovelace" };
+		rerender(
+			<RowDetailsSheet
+				tableName="users"
+				rows={updatedRows}
+			/>,
+		);
+
+		expect(screen.getByDisplayValue("Ada Lovelace")).toBeInTheDocument();
+	});
+
+	it("preserves dirty fields when refreshed row has the same record identity", async () => {
+		useOverlayStore.getState().openOverlay("tables.row-details");
+		useRowDetailsStore.getState().setRowDetails("users", 0);
+		const { rerender } = render(
+			<RowDetailsSheet
+				tableName="users"
+				rows={fixtures.rows}
+			/>,
+		);
+
+		const nameInput = screen.getByDisplayValue("Ada");
+		await user.clear(nameInput);
+		await user.type(nameInput, "Grace");
+
+		const updatedRows = makeRows();
+		updatedRows[0] = { ...updatedRows[0], age: 37 };
+		rerender(
+			<RowDetailsSheet
+				tableName="users"
+				rows={updatedRows}
+			/>,
+		);
+
+		expect(screen.getByDisplayValue("Grace")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("37")).toBeInTheDocument();
+	});
+
+	it("resets to new record values when row identity changes underneath", async () => {
+		useOverlayStore.getState().openOverlay("tables.row-details");
+		useRowDetailsStore.getState().setRowDetails("users", 0);
+		const { rerender } = render(
+			<RowDetailsSheet
+				tableName="users"
+				rows={fixtures.rows}
+			/>,
+		);
+
+		const nameInput = screen.getByDisplayValue("Ada");
+		await user.clear(nameInput);
+		await user.type(nameInput, "Grace");
+
+		const reorderedRows = [fixtures.rows[1], fixtures.rows[0]];
+		rerender(
+			<RowDetailsSheet
+				tableName="users"
+				rows={reorderedRows}
+			/>,
+		);
+
+		expect(screen.getByDisplayValue("Bob")).toBeInTheDocument();
+		expect(screen.queryByDisplayValue("Grace")).not.toBeInTheDocument();
+	});
 });

--- a/packages/web/src/features/tables/components/row-details-sheet.test.tsx
+++ b/packages/web/src/features/tables/components/row-details-sheet.test.tsx
@@ -190,6 +190,11 @@ describe("RowDetailsSheet", () => {
 		expect(screen.getByRole("group", { name: "is_active" })).toBeInTheDocument();
 		expect(screen.getByRole("group", { name: "role" })).toBeInTheDocument();
 		expect(screen.getByRole("group", { name: "created" })).toBeInTheDocument();
+		// Text, number, and JSON inputs are named directly.
+		expect(screen.getByRole("textbox", { name: "name" })).toBeInTheDocument();
+		expect(screen.getByRole("spinbutton", { name: "age" })).toBeInTheDocument();
+		expect(screen.getByRole("textbox", { name: "meta" })).toBeInTheDocument();
+		expect(screen.getByRole("combobox", { name: "is_active" })).toBeInTheDocument();
 	});
 
 	it("renders generated primary keys read-only", () => {

--- a/packages/web/src/features/tables/components/row-details-sheet.test.tsx
+++ b/packages/web/src/features/tables/components/row-details-sheet.test.tsx
@@ -567,4 +567,47 @@ describe("RowDetailsSheet", () => {
 		expect(screen.getByDisplayValue("Bob")).toBeInTheDocument();
 		expect(screen.queryByDisplayValue("Grace")).not.toBeInTheDocument();
 	});
+
+	it("preserves dirty state and baseline after row refresh and subsequent edits", async () => {
+		useOverlayStore.getState().openOverlay("tables.row-details");
+		useRowDetailsStore.getState().setRowDetails("users", 0);
+		const { rerender } = render(
+			<RowDetailsSheet
+				tableName="users"
+				rows={fixtures.rows}
+			/>,
+		);
+
+		const nameInput = screen.getByDisplayValue("Ada");
+		await user.clear(nameInput);
+		await user.type(nameInput, "Grace");
+
+		const saveButton = screen.getByRole("button", { name: "Save changes" });
+		expect(saveButton).toBeEnabled();
+
+		// Refresh from server with updated age, keeping same id: 1
+		const updatedRows = makeRows();
+		updatedRows[0] = { ...updatedRows[0], age: 37 };
+		rerender(
+			<RowDetailsSheet
+				tableName="users"
+				rows={updatedRows}
+			/>,
+		);
+
+		expect(screen.getByDisplayValue("Grace")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("37")).toBeInTheDocument();
+		expect(saveButton).toBeEnabled();
+
+		// Change name again
+		await user.type(nameInput, " Hopper");
+		expect(screen.getByDisplayValue("Grace Hopper")).toBeInTheDocument();
+		expect(saveButton).toBeEnabled();
+
+		// Restore name back to Grace
+		await user.clear(nameInput);
+		await user.type(nameInput, "Grace");
+		expect(screen.getByDisplayValue("Grace")).toBeInTheDocument();
+		expect(saveButton).toBeEnabled();
+	});
 });

--- a/packages/web/src/features/tables/components/row-details-sheet.tsx
+++ b/packages/web/src/features/tables/components/row-details-sheet.tsx
@@ -1,0 +1,485 @@
+import type { ColumnInfoSchemaType } from "@db-studio/shared/types";
+import { Alert } from "@db-studio/ui/alert";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@db-studio/ui/alert-dialog";
+import { Button } from "@db-studio/ui/button";
+import { Check, ChevronDown, ChevronUp, Copy, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { FormProvider, useForm, useFormContext } from "react-hook-form";
+import { useHotkeys } from "react-hotkeys-hook";
+import { SheetSidebar } from "@/components/sheet-sidebar";
+import { AddRecordField, RecordReferenceSheet } from "@/features/records";
+import { useTableCols } from "@/features/schema";
+import { useOverlayStore } from "@/stores/overlay.store";
+import type { TableRecord } from "@/types/table.type";
+import { formatCellValue } from "@/utils/format-cell-value";
+import { useDeleteCells } from "../hooks/use-delete-cell";
+import { useUpdateRecord } from "../hooks/use-update-record";
+import { useRowDetailsStore } from "../stores/row-details.store";
+import {
+	buildRowUpdates,
+	copyTextToClipboard,
+	getPrimaryKeyColumn,
+	isGeneratedColumn,
+	toFormValues,
+} from "./row-details-utils";
+
+type PendingAction = null | "close" | "delete" | number;
+
+const CopyValueButton = ({ value }: { value: string }) => {
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		if (!copied) return;
+		const timeout = window.setTimeout(() => setCopied(false), 1200);
+		return () => window.clearTimeout(timeout);
+	}, [copied]);
+
+	if (!value) return null;
+
+	return (
+		<button
+			type="button"
+			aria-label={copied ? "Copied" : "Copy value"}
+			className="inline-flex size-7 shrink-0 items-center justify-center rounded-md border border-input bg-background text-muted-foreground transition-colors hover:text-foreground"
+			onClick={() => {
+				void copyTextToClipboard(value)
+					.then(() => setCopied(true))
+					.catch(() => undefined);
+			}}
+		>
+			{copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+		</button>
+	);
+};
+
+const RowDetailsField = ({
+	column,
+	displayValue,
+	readOnly,
+}: {
+	column: ColumnInfoSchemaType;
+	displayValue: string;
+	readOnly: boolean;
+}) => {
+	const { watch, formState } = useFormContext<Record<string, string>>();
+	const liveValue = watch(column.columnName) ?? "";
+	const dirty = Boolean(formState.dirtyFields[column.columnName]);
+
+	return (
+		<div className="grid grid-cols-3 gap-4">
+			<div className="col-span-1 flex flex-col gap-1">
+				<span className="text-sm font-medium">
+					{column.columnName}
+					{dirty && (
+						<span className="ml-1.5 inline-block size-1.5 rounded-full bg-primary">
+							<span className="sr-only">(modified)</span>
+						</span>
+					)}
+				</span>
+				<span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+					{column.dataTypeLabel}
+					{column.isPrimaryKey && (
+						<span className="rounded border border-border bg-muted px-1 font-mono text-[10px]">
+							PK
+						</span>
+					)}
+				</span>
+			</div>
+			<div className="col-span-2 flex w-full items-start gap-2">
+				<div className="min-w-0 flex-1">
+					{readOnly ? (
+						<div
+							role="group"
+							aria-label={column.columnName}
+							className="break-all rounded-md border border-input bg-muted/40 px-3 py-2 text-sm"
+						>
+							{displayValue || <span className="text-muted-foreground">NULL</span>}
+						</div>
+					) : (
+						<AddRecordField
+							{...column}
+							hideLabel
+						/>
+					)}
+				</div>
+				<CopyValueButton value={readOnly ? displayValue : formatCellValue(liveValue)} />
+			</div>
+		</div>
+	);
+};
+
+export const RowDetailsSheet = ({
+	tableName,
+	rows,
+}: {
+	tableName: string;
+	rows: TableRecord[];
+}) => {
+	const { closeOverlay, isOverlayOpen } = useOverlayStore();
+	const { rowIndex, selectRowDetails, clearRowDetails } = useRowDetailsStore();
+	const { tableCols, isLoadingTableCols } = useTableCols({ tableName });
+	const { updateRecord, isUpdatingRecord } = useUpdateRecord({ tableName });
+	const { deleteCells, isDeletingCells } = useDeleteCells({ tableName });
+
+	const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+	const [showPkConfirm, setShowPkConfirm] = useState(false);
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+	const [pendingSave, setPendingSave] = useState<Record<string, string> | null>(null);
+
+	const open = isOverlayOpen("tables.row-details") && rowIndex !== null;
+	const row = rowIndex === null ? undefined : rows[rowIndex];
+	const isBusy = isUpdatingRecord || isDeletingCells;
+
+	const primaryKeyColumn = useMemo(() => getPrimaryKeyColumn(tableCols), [tableCols]);
+	// The server falls back to an "id" column when no primary key is sent, so
+	// saving works for keyless tables that still carry an "id" column.
+	const identityColumn = useMemo(
+		() => primaryKeyColumn ?? tableCols?.find((col) => col.columnName === "id"),
+		[primaryKeyColumn, tableCols],
+	);
+	const columnsSignature = useMemo(
+		() => JSON.stringify((tableCols ?? []).map((col) => col.columnName)),
+		[tableCols],
+	);
+
+	const methods = useForm<Record<string, string>>({
+		defaultValues: useMemo(() => toFormValues(row, tableCols), [row, tableCols]),
+	});
+	const { formState, reset, handleSubmit } = methods;
+	const isDirty = formState.isDirty;
+	const pkDirty = primaryKeyColumn
+		? Boolean(formState.dirtyFields[primaryKeyColumn.columnName])
+		: false;
+
+	// Reset the form when a different row is selected. `row` itself is
+	// intentionally excluded: background refetches allocate new row objects
+	// with identical content, and resetting on those would wipe in-progress
+	// edits. Reordering underneath an open modal sheet cannot happen (Radix
+	// dialogs are modal), so index-anchored selection stays correct.
+	useEffect(() => {
+		methods.reset(toFormValues(row, tableCols));
+	}, [methods, tableName, rowIndex, columnsSignature]);
+
+	// The selected index can fall off the page after the data changes.
+	useEffect(() => {
+		if (open && rowIndex !== null && !rows[rowIndex]) {
+			if (isDirty) {
+				setPendingAction("close");
+			} else {
+				clearRowDetails();
+				closeOverlay("tables.row-details");
+			}
+		}
+	}, [open, rowIndex, rows, isDirty, clearRowDetails, closeOverlay]);
+
+	const closeSheet = () => {
+		clearRowDetails();
+		closeOverlay("tables.row-details");
+	};
+
+	const requestClose = () => {
+		if (isBusy) return;
+		if (isDirty) {
+			setPendingAction("close");
+		} else {
+			closeSheet();
+		}
+	};
+
+	const requestNavigate = (index: number) => {
+		if (isBusy || index === rowIndex || index < 0 || index >= rows.length) return;
+		if (isDirty) {
+			setPendingAction(index);
+		} else {
+			selectRowDetails(index);
+		}
+	};
+
+	const requestDelete = () => {
+		if (isBusy) return;
+		if (isDirty) {
+			setPendingAction("delete");
+		} else {
+			setShowDeleteConfirm(true);
+		}
+	};
+
+	const confirmDiscard = () => {
+		const action = pendingAction;
+		setPendingAction(null);
+		if (action === "close") {
+			closeSheet();
+		} else if (action === "delete") {
+			setShowDeleteConfirm(true);
+		} else if (typeof action === "number") {
+			selectRowDetails(action);
+		}
+	};
+
+	const doSave = async (data: Record<string, string>) => {
+		if (!row) return;
+		const updates = buildRowUpdates(formState.dirtyFields, data);
+		if (updates.length === 0) return;
+		try {
+			await updateRecord({
+				rowData: row,
+				updates,
+				primaryKey: identityColumn?.columnName,
+			});
+			reset(data);
+			closeSheet();
+		} catch {
+			// The mutation hook already reported the failure through toast.promise.
+		}
+	};
+
+	const onSubmit = (data: Record<string, string>) => {
+		if (pkDirty) {
+			setPendingSave(data);
+			setShowPkConfirm(true);
+			return;
+		}
+		void doSave(data);
+	};
+
+	const confirmDelete = async () => {
+		if (!row) return;
+		setShowDeleteConfirm(false);
+		try {
+			const result = await deleteCells([row]);
+			if (result.deletedCount > 0) {
+				closeSheet();
+			}
+		} catch {
+			// The mutation hook already reported the failure through toast.promise.
+		}
+	};
+
+	const canPrev = rowIndex !== null && rowIndex > 0;
+	const canNext = rowIndex !== null && rowIndex < rows.length - 1;
+
+	// Up/Down moves between rows. react-hotkeys-hook ignores form tags by
+	// default, so navigation pauses while an editor is focused, per spec.
+	useHotkeys(
+		"up, down",
+		(event) => {
+			if (rowIndex === null) return;
+			event.preventDefault();
+			requestNavigate(event.key === "ArrowUp" ? rowIndex - 1 : rowIndex + 1);
+		},
+		{ enabled: open && !isBusy },
+		[open, isBusy, rowIndex, rows.length, isDirty],
+	);
+
+	return (
+		<>
+			<SheetSidebar
+				title="Row details"
+				description={
+					rowIndex !== null
+						? `${tableName} · Row ${rowIndex + 1} of ${rows.length}`
+						: tableName
+				}
+				cta={
+					<div className="flex items-center gap-1">
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-sm"
+							aria-label="Previous row"
+							disabled={!canPrev || isBusy}
+							onClick={() => rowIndex !== null && requestNavigate(rowIndex - 1)}
+						>
+							<ChevronUp className="size-4" />
+						</Button>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-sm"
+							aria-label="Next row"
+							disabled={!canNext || isBusy}
+							onClick={() => rowIndex !== null && requestNavigate(rowIndex + 1)}
+						>
+							<ChevronDown className="size-4" />
+						</Button>
+					</div>
+				}
+				open={open}
+				onOpenChange={(isOpen) => {
+					if (!isOpen) {
+						requestClose();
+					}
+				}}
+			>
+				{tableCols && tableCols.length > 0 && row ? (
+					<FormProvider {...methods}>
+						<form
+							onSubmit={handleSubmit(onSubmit)}
+							className="flex flex-col h-full"
+						>
+							<div className="space-y-6">
+								{tableCols.map((col) => (
+									<RowDetailsField
+										key={col.columnName}
+										column={col}
+										displayValue={formatCellValue(row[col.columnName])}
+										readOnly={isGeneratedColumn(col)}
+									/>
+								))}
+							</div>
+
+							<div className="flex items-center justify-between gap-2 py-6">
+								<Button
+									type="button"
+									variant="destructive"
+									size="lg"
+									disabled={isBusy || !primaryKeyColumn}
+									title={
+										primaryKeyColumn
+											? undefined
+											: "Records in tables without a primary key can't be deleted"
+									}
+									onClick={requestDelete}
+								>
+									<Trash2 className="size-4" />
+									Delete
+								</Button>
+
+								<div className="flex gap-2">
+									<Button
+										type="button"
+										variant="outline"
+										size="lg"
+										disabled={isBusy}
+										onClick={requestClose}
+									>
+										Close
+									</Button>
+									<Button
+										type="submit"
+										size="lg"
+										disabled={isBusy || !isDirty || !identityColumn}
+										title={
+											identityColumn
+												? undefined
+												: "Saving needs a primary key or an id column to address the record"
+										}
+									>
+										Save changes
+									</Button>
+								</div>
+							</div>
+						</form>
+
+						<RecordReferenceSheet />
+					</FormProvider>
+				) : (
+					<div className="flex flex-col h-full">
+						<div className="space-y-6">
+							{isLoadingTableCols ? (
+								<p className="text-sm text-muted-foreground">Loading row details...</p>
+							) : (
+								<Alert
+									variant="info"
+									title="No columns found"
+									message="Please add at least one column to the table before viewing records."
+								/>
+							)}
+						</div>
+					</div>
+				)}
+			</SheetSidebar>
+
+			<AlertDialog
+				open={pendingAction !== null}
+				onOpenChange={(isOpen) => {
+					if (!isOpen) {
+						setPendingAction(null);
+					}
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Discard unsaved changes?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This record has unsaved changes. Discard them and continue?
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Keep editing</AlertDialogCancel>
+						<AlertDialogAction onClick={confirmDiscard}>Discard changes</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<AlertDialog
+				open={showPkConfirm}
+				onOpenChange={(isOpen) => {
+					setShowPkConfirm(isOpen);
+					if (!isOpen) {
+						setPendingSave(null);
+					}
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Change the primary key?</AlertDialogTitle>
+						<AlertDialogDescription>
+							Changing the primary key changes the identity of this record. Existing references
+							to the old key may break. Are you sure?
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => {
+								setShowPkConfirm(false);
+								if (pendingSave) {
+									void doSave(pendingSave);
+									setPendingSave(null);
+								}
+							}}
+						>
+							Change primary key
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<AlertDialog
+				open={showDeleteConfirm}
+				onOpenChange={setShowDeleteConfirm}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete record</AlertDialogTitle>
+						<AlertDialogDescription>
+							Are you sure you want to delete this record from "{tableName}"? This action
+							cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							variant="destructive"
+							onClick={() => {
+								void confirmDelete();
+							}}
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</>
+	);
+};

--- a/packages/web/src/features/tables/components/row-details-sheet.tsx
+++ b/packages/web/src/features/tables/components/row-details-sheet.tsx
@@ -12,7 +12,7 @@ import {
 } from "@db-studio/ui/alert-dialog";
 import { Button } from "@db-studio/ui/button";
 import { Check, ChevronDown, ChevronUp, Copy, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import { useHotkeys } from "react-hotkeys-hook";
 import { SheetSidebar } from "@/components/sheet-sidebar";
@@ -28,6 +28,7 @@ import {
 	buildRowUpdates,
 	copyTextToClipboard,
 	getPrimaryKeyColumn,
+	getRecordIdentity,
 	isGeneratedColumn,
 	toFormValues,
 } from "./row-details-utils";
@@ -160,14 +161,74 @@ export const RowDetailsSheet = ({
 		? Boolean(formState.dirtyFields[primaryKeyColumn.columnName])
 		: false;
 
-	// Reset the form when a different row is selected. `row` itself is
-	// intentionally excluded: background refetches allocate new row objects
-	// with identical content, and resetting on those would wipe in-progress
-	// edits. Reordering underneath an open modal sheet cannot happen (Radix
-	// dialogs are modal), so index-anchored selection stays correct.
+	const lastRowRef = useRef<TableRecord | undefined>(undefined);
+	const lastRecordIdentityRef = useRef<string | undefined>(undefined);
+	const lastRowIndexRef = useRef<number | null>(null);
+	const lastTableNameRef = useRef<string | null>(null);
+	const lastColsSigRef = useRef<string>(columnsSignature);
+
+	// Synchronize form values with the active row. An untouched draft resets from
+	// the refreshed row so displayed values stay consistent. Dirty edits are preserved
+	// only when the refreshed row has the same stable record identity.
 	useEffect(() => {
-		methods.reset(toFormValues(row, tableCols));
-	}, [methods, tableName, rowIndex, columnsSignature]);
+		const currentIdentity = getRecordIdentity(row, tableCols);
+		const isSameSelection =
+			tableName === lastTableNameRef.current &&
+			rowIndex === lastRowIndexRef.current &&
+			columnsSignature === lastColsSigRef.current;
+
+		if (!isSameSelection) {
+			lastTableNameRef.current = tableName;
+			lastRowIndexRef.current = rowIndex;
+			lastColsSigRef.current = columnsSignature;
+			lastRowRef.current = row;
+			lastRecordIdentityRef.current = currentIdentity;
+			methods.reset(toFormValues(row, tableCols));
+			return;
+		}
+
+		if (row === lastRowRef.current) {
+			return;
+		}
+		lastRowRef.current = row;
+
+		const freshValues = toFormValues(row, tableCols);
+
+		if (!isDirty) {
+			lastRecordIdentityRef.current = currentIdentity;
+			methods.reset(freshValues);
+			return;
+		}
+
+		const sameIdentity =
+			currentIdentity !== undefined &&
+			lastRecordIdentityRef.current !== undefined &&
+			currentIdentity === lastRecordIdentityRef.current;
+
+		if (sameIdentity) {
+			const dirtyFields = formState.dirtyFields;
+			const currentValues = methods.getValues();
+			const mergedValues: Record<string, string> = { ...freshValues };
+			for (const [key, isFieldDirty] of Object.entries(dirtyFields)) {
+				if (isFieldDirty && key in currentValues) {
+					mergedValues[key] = currentValues[key];
+				}
+			}
+			methods.reset(mergedValues, { keepDirty: true });
+		} else {
+			lastRecordIdentityRef.current = currentIdentity;
+			methods.reset(freshValues);
+		}
+	}, [
+		row,
+		tableCols,
+		tableName,
+		rowIndex,
+		columnsSignature,
+		methods,
+		isDirty,
+		formState.dirtyFields,
+	]);
 
 	// The selected index can fall off the page after the data changes.
 	useEffect(() => {

--- a/packages/web/src/features/tables/components/row-details-sheet.tsx
+++ b/packages/web/src/features/tables/components/row-details-sheet.tsx
@@ -206,29 +206,12 @@ export const RowDetailsSheet = ({
 			currentIdentity === lastRecordIdentityRef.current;
 
 		if (sameIdentity) {
-			const dirtyFields = formState.dirtyFields;
-			const currentValues = methods.getValues();
-			const mergedValues: Record<string, string> = { ...freshValues };
-			for (const [key, isFieldDirty] of Object.entries(dirtyFields)) {
-				if (isFieldDirty && key in currentValues) {
-					mergedValues[key] = currentValues[key];
-				}
-			}
-			methods.reset(mergedValues, { keepDirty: true });
+			methods.reset(freshValues, { keepDirtyValues: true });
 		} else {
 			lastRecordIdentityRef.current = currentIdentity;
 			methods.reset(freshValues);
 		}
-	}, [
-		row,
-		tableCols,
-		tableName,
-		rowIndex,
-		columnsSignature,
-		methods,
-		isDirty,
-		formState.dirtyFields,
-	]);
+	}, [row, tableCols, tableName, rowIndex, columnsSignature, methods, isDirty]);
 
 	// The selected index can fall off the page after the data changes.
 	useEffect(() => {

--- a/packages/web/src/features/tables/components/row-details-utils.test.ts
+++ b/packages/web/src/features/tables/components/row-details-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	buildRowUpdates,
 	getPrimaryKeyColumn,
+	getRecordIdentity,
 	isGeneratedColumn,
 	toFormValues,
 } from "./row-details-utils";
@@ -63,6 +64,34 @@ describe("row-details-utils", () => {
 		it("returns undefined without a primary key", () => {
 			expect(getPrimaryKeyColumn([])).toBeUndefined();
 			expect(getPrimaryKeyColumn(undefined)).toBeUndefined();
+		});
+	});
+
+	describe("getRecordIdentity", () => {
+		it("returns primary key identity for single key", () => {
+			expect(getRecordIdentity({ id: 1, code: "A" }, [...cols])).toBe("id:1");
+		});
+
+		it("returns composite primary key identity", () => {
+			const compositeCols = [
+				{ ...cols[0], columnName: "tenant_id", isPrimaryKey: true },
+				{ ...cols[1], columnName: "user_id", isPrimaryKey: true },
+			];
+			expect(getRecordIdentity({ tenant_id: "org_1", user_id: 42 }, compositeCols)).toBe(
+				"tenant_id:org_1|user_id:42",
+			);
+		});
+
+		it("falls back to id column without a primary key", () => {
+			const nonPkCols = cols.map((col) => ({ ...col, isPrimaryKey: false }));
+			expect(getRecordIdentity({ id: 123, code: "A" }, nonPkCols)).toBe("id:123");
+		});
+
+		it("returns undefined when no key or id is present", () => {
+			const noIdCols = [{ ...cols[1], columnName: "title", isPrimaryKey: false }];
+			expect(getRecordIdentity({ title: "test" }, noIdCols)).toBeUndefined();
+			expect(getRecordIdentity(undefined, cols)).toBeUndefined();
+			expect(getRecordIdentity({ id: 1 }, undefined)).toBeUndefined();
 		});
 	});
 

--- a/packages/web/src/features/tables/components/row-details-utils.test.ts
+++ b/packages/web/src/features/tables/components/row-details-utils.test.ts
@@ -69,22 +69,38 @@ describe("row-details-utils", () => {
 
 	describe("getRecordIdentity", () => {
 		it("returns primary key identity for single key", () => {
-			expect(getRecordIdentity({ id: 1, code: "A" }, [...cols])).toBe("id:1");
+			expect(getRecordIdentity({ id: 1, code: "A" }, [...cols])).toBe(
+				JSON.stringify([["id", "1"]]),
+			);
 		});
 
-		it("returns composite primary key identity", () => {
+		it("returns composite primary key identity without delimiter collisions", () => {
 			const compositeCols = [
 				{ ...cols[0], columnName: "tenant_id", isPrimaryKey: true },
 				{ ...cols[1], columnName: "user_id", isPrimaryKey: true },
 			];
-			expect(getRecordIdentity({ tenant_id: "org_1", user_id: 42 }, compositeCols)).toBe(
-				"tenant_id:org_1|user_id:42",
+			const id1 = getRecordIdentity({ tenant_id: "org:1|part", user_id: "42" }, compositeCols);
+			const id2 = getRecordIdentity({ tenant_id: "org", user_id: "1|part:42" }, compositeCols);
+			expect(id1).toBe(
+				JSON.stringify([
+					["tenant_id", "org:1|part"],
+					["user_id", "42"],
+				]),
 			);
+			expect(id2).toBe(
+				JSON.stringify([
+					["tenant_id", "org"],
+					["user_id", "1|part:42"],
+				]),
+			);
+			expect(id1).not.toBe(id2);
 		});
 
 		it("falls back to id column without a primary key", () => {
 			const nonPkCols = cols.map((col) => ({ ...col, isPrimaryKey: false }));
-			expect(getRecordIdentity({ id: 123, code: "A" }, nonPkCols)).toBe("id:123");
+			expect(getRecordIdentity({ id: 123, code: "A" }, nonPkCols)).toBe(
+				JSON.stringify(["id", "123"]),
+			);
 		});
 
 		it("returns undefined when no key or id is present", () => {

--- a/packages/web/src/features/tables/components/row-details-utils.test.ts
+++ b/packages/web/src/features/tables/components/row-details-utils.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildRowUpdates,
+	getPrimaryKeyColumn,
+	isGeneratedColumn,
+	toFormValues,
+} from "./row-details-utils";
+
+const cols = [
+	{
+		columnName: "id",
+		dataType: "number",
+		dataTypeLabel: "int",
+		isNullable: false,
+		columnDefault: "nextval('users_id_seq'::regclass)",
+		isPrimaryKey: true,
+		isForeignKey: false,
+		referencedTable: null,
+		referencedColumn: null,
+		enumValues: null,
+	},
+	{
+		columnName: "code",
+		dataType: "text",
+		dataTypeLabel: "text",
+		isNullable: false,
+		columnDefault: null,
+		isPrimaryKey: false,
+		isForeignKey: false,
+		referencedTable: null,
+		referencedColumn: null,
+		enumValues: null,
+	},
+] as const;
+
+describe("row-details-utils", () => {
+	describe("isGeneratedColumn", () => {
+		it("detects sequence defaults", () => {
+			expect(isGeneratedColumn({ columnDefault: "nextval('users_id_seq'::regclass)" })).toBe(
+				true,
+			);
+		});
+
+		it("detects identity and auto-increment defaults", () => {
+			expect(isGeneratedColumn({ columnDefault: "auto_increment" })).toBe(true);
+			expect(isGeneratedColumn({ columnDefault: "AUTOINCREMENT" })).toBe(true);
+			expect(isGeneratedColumn({ columnDefault: "generated always as identity" })).toBe(true);
+			expect(isGeneratedColumn({ columnDefault: "IDENTITY(1,1)" })).toBe(true);
+		});
+
+		it("treats plain columns as editable", () => {
+			expect(isGeneratedColumn({ columnDefault: null })).toBe(false);
+			expect(isGeneratedColumn({ columnDefault: "now()" })).toBe(false);
+			expect(isGeneratedColumn({ columnDefault: "'active'" })).toBe(false);
+		});
+	});
+
+	describe("getPrimaryKeyColumn", () => {
+		it("returns the primary key column", () => {
+			expect(getPrimaryKeyColumn([...cols])?.columnName).toBe("id");
+		});
+
+		it("returns undefined without a primary key", () => {
+			expect(getPrimaryKeyColumn([])).toBeUndefined();
+			expect(getPrimaryKeyColumn(undefined)).toBeUndefined();
+		});
+	});
+
+	describe("toFormValues", () => {
+		it("stringifies values for form controls", () => {
+			expect(
+				toFormValues({ id: 1, code: "A", active: true, meta: { a: 1 }, missing: null }, [
+					...cols,
+				]),
+			).toEqual({ id: "1", code: "A" });
+		});
+
+		it("returns empty values without a row or columns", () => {
+			expect(toFormValues(undefined, [...cols])).toEqual({});
+			expect(toFormValues({ id: 1 }, undefined)).toEqual({});
+		});
+	});
+
+	describe("buildRowUpdates", () => {
+		it("maps dirty fields to update payloads", () => {
+			expect(buildRowUpdates({ code: true, id: false }, { id: "1", code: "B" })).toEqual([
+				{ columnName: "code", value: "B" },
+			]);
+		});
+
+		it("returns no updates when nothing is dirty", () => {
+			expect(buildRowUpdates({}, { id: "1" })).toEqual([]);
+		});
+	});
+});

--- a/packages/web/src/features/tables/components/row-details-utils.ts
+++ b/packages/web/src/features/tables/components/row-details-utils.ts
@@ -1,0 +1,65 @@
+import type { ColumnInfoSchemaType } from "@db-studio/shared/types";
+import type { TableRecord } from "@/types/table.type";
+
+// Column defaults that mean the database fills the value itself
+// (serial sequences, identities, auto-increment, generated UUIDs).
+const GENERATED_DEFAULT_PATTERNS = [
+	"nextval(",
+	"next_value",
+	"auto_increment",
+	"autoincrement",
+	"identity",
+	"uuid_generate",
+	"gen_random_uuid",
+	"newid(",
+	"newsequentialid(",
+];
+
+export const isGeneratedColumn = (
+	column: Pick<ColumnInfoSchemaType, "columnDefault">,
+): boolean => {
+	const columnDefault = column.columnDefault?.toLowerCase() ?? "";
+	return GENERATED_DEFAULT_PATTERNS.some((pattern) => columnDefault.includes(pattern));
+};
+
+export const getPrimaryKeyColumn = (
+	tableCols: ColumnInfoSchemaType[] | undefined,
+): ColumnInfoSchemaType | undefined => tableCols?.find((col) => col.isPrimaryKey);
+
+export const toFormValues = (
+	row: TableRecord | undefined,
+	tableCols: ColumnInfoSchemaType[] | undefined,
+): Record<string, string> => {
+	const values: Record<string, string> = {};
+	if (!row || !tableCols) return values;
+	for (const col of tableCols) {
+		const value = row[col.columnName];
+		if (value === null || value === undefined) {
+			values[col.columnName] = "";
+		} else if (typeof value === "boolean") {
+			values[col.columnName] = value ? "true" : "false";
+		} else if (typeof value === "object") {
+			try {
+				values[col.columnName] = JSON.stringify(value);
+			} catch {
+				values[col.columnName] = String(value);
+			}
+		} else {
+			values[col.columnName] = String(value);
+		}
+	}
+	return values;
+};
+
+export const buildRowUpdates = (
+	dirtyFields: Partial<Record<string, boolean>>,
+	values: Record<string, string>,
+): Array<{ columnName: string; value: unknown }> =>
+	Object.keys(dirtyFields)
+		.filter((columnName) => dirtyFields[columnName])
+		.map((columnName) => ({ columnName, value: values[columnName] ?? "" }));
+
+// Separate seam so tests can mock clipboard access without patching globals.
+export const copyTextToClipboard = async (value: string): Promise<void> => {
+	await navigator.clipboard.writeText(value);
+};

--- a/packages/web/src/features/tables/components/row-details-utils.ts
+++ b/packages/web/src/features/tables/components/row-details-utils.ts
@@ -26,6 +26,22 @@ export const getPrimaryKeyColumn = (
 	tableCols: ColumnInfoSchemaType[] | undefined,
 ): ColumnInfoSchemaType | undefined => tableCols?.find((col) => col.isPrimaryKey);
 
+export const getRecordIdentity = (
+	row: TableRecord | undefined,
+	tableCols: ColumnInfoSchemaType[] | undefined,
+): string | undefined => {
+	if (!row || !tableCols) return undefined;
+	const pkCols = tableCols.filter((col) => col.isPrimaryKey);
+	if (pkCols.length > 0) {
+		return pkCols.map((col) => `${col.columnName}:${String(row[col.columnName])}`).join("|");
+	}
+	const idCol = tableCols.find((col) => col.columnName === "id");
+	if (idCol && row[idCol.columnName] !== undefined && row[idCol.columnName] !== null) {
+		return `id:${String(row[idCol.columnName])}`;
+	}
+	return undefined;
+};
+
 export const toFormValues = (
 	row: TableRecord | undefined,
 	tableCols: ColumnInfoSchemaType[] | undefined,

--- a/packages/web/src/features/tables/components/row-details-utils.ts
+++ b/packages/web/src/features/tables/components/row-details-utils.ts
@@ -33,11 +33,11 @@ export const getRecordIdentity = (
 	if (!row || !tableCols) return undefined;
 	const pkCols = tableCols.filter((col) => col.isPrimaryKey);
 	if (pkCols.length > 0) {
-		return pkCols.map((col) => `${col.columnName}:${String(row[col.columnName])}`).join("|");
+		return JSON.stringify(pkCols.map((col) => [col.columnName, String(row[col.columnName])]));
 	}
 	const idCol = tableCols.find((col) => col.columnName === "id");
 	if (idCol && row[idCol.columnName] !== undefined && row[idCol.columnName] !== null) {
-		return `id:${String(row[idCol.columnName])}`;
+		return JSON.stringify([idCol.columnName, String(row[idCol.columnName])]);
 	}
 	return undefined;
 };

--- a/packages/web/src/features/tables/components/table-body-row.tsx
+++ b/packages/web/src/features/tables/components/table-body-row.tsx
@@ -1,11 +1,15 @@
 import { flexRender, type Row } from "@tanstack/react-table";
 import type { VirtualItem, Virtualizer } from "@tanstack/react-virtual";
+import { useOverlayStore } from "@/stores/overlay.store";
 import type { TableRecord } from "@/types/table.type";
+import { useDelayedRowOpen } from "../hooks/use-delayed-row-open";
+import { useRowDetailsStore } from "../stores/row-details.store";
 import { CellCopyButton } from "./cell-copy-button";
 
 interface TableBodyRowProps {
 	columnVirtualizer: Virtualizer<HTMLDivElement, HTMLTableCellElement>;
 	row: Row<TableRecord>;
+	tableName: string;
 	rowVirtualizer: Virtualizer<HTMLDivElement, HTMLTableRowElement>;
 	virtualPaddingLeft: number | undefined;
 	virtualPaddingRight: number | undefined;
@@ -15,6 +19,7 @@ interface TableBodyRowProps {
 export const TableBodyRow = ({
 	columnVirtualizer,
 	row,
+	tableName,
 	rowVirtualizer,
 	virtualPaddingLeft,
 	virtualPaddingRight,
@@ -22,6 +27,13 @@ export const TableBodyRow = ({
 }: TableBodyRowProps) => {
 	const visibleCells = row.getVisibleCells();
 	const virtualColumns = columnVirtualizer.getVirtualItems();
+	const { schedule, cancel } = useDelayedRowOpen();
+
+	const openRowDetails = () => {
+		useRowDetailsStore.getState().setRowDetails(tableName, virtualRow.index);
+		useOverlayStore.getState().openOverlay("tables.row-details");
+	};
+
 	return (
 		<tr
 			data-index={virtualRow.index} //needed for dynamic row height measurement
@@ -31,6 +43,23 @@ export const TableBodyRow = ({
 			style={{
 				transform: `translateY(${virtualRow.start}px)`, //this should always be a `style` as it changes on scroll
 			}}
+			onClick={(event) => {
+				// Ordinary row content opens the details sheet. Interactive
+				// elements (their own handlers stop propagation as well) and
+				// editor surfaces never do.
+				const target = event.target as HTMLElement;
+				if (
+					target.closest(
+						"button, a, input, textarea, select, [role=checkbox], [role=listbox], [role=dialog], [data-grid-cell-editor]",
+					)
+				) {
+					return;
+				}
+				schedule(openRowDetails);
+			}}
+			// A double-click starts inline cell editing instead (handled by
+			// the cell wrapper), so it cancels the pending sheet.
+			onDoubleClick={cancel}
 		>
 			{virtualPaddingLeft ? (
 				// fake empty column to the left for virtualization scroll padding

--- a/packages/web/src/features/tables/components/table-body.tsx
+++ b/packages/web/src/features/tables/components/table-body.tsx
@@ -7,6 +7,7 @@ import { TableBodyRow } from "./table-body-row";
 interface TableBodyProps {
 	columnVirtualizer: Virtualizer<HTMLDivElement, HTMLTableCellElement>;
 	table: Table<TableRecord>;
+	tableName: string;
 	tableContainerRef: RefObject<HTMLDivElement | null>;
 	virtualPaddingLeft: number | undefined;
 	virtualPaddingRight: number | undefined;
@@ -15,6 +16,7 @@ interface TableBodyProps {
 export const TableBody = ({
 	columnVirtualizer,
 	table,
+	tableName,
 	tableContainerRef,
 	virtualPaddingLeft,
 	virtualPaddingRight,
@@ -52,6 +54,7 @@ export const TableBody = ({
 						columnVirtualizer={columnVirtualizer}
 						key={row.id}
 						row={row}
+						tableName={tableName}
 						rowVirtualizer={rowVirtualizer}
 						virtualPaddingLeft={virtualPaddingLeft}
 						virtualPaddingRight={virtualPaddingRight}

--- a/packages/web/src/features/tables/components/table-container.tsx
+++ b/packages/web/src/features/tables/components/table-container.tsx
@@ -5,7 +5,13 @@ import type { TableRecord } from "@/types/table.type";
 import { TableBody } from "./table-body";
 import { TableHead } from "./table-head";
 
-export const TableContainer = ({ table }: { table: Table<TableRecord> }) => {
+export const TableContainer = ({
+	table,
+	tableName,
+}: {
+	table: Table<TableRecord>;
+	tableName: string;
+}) => {
 	const visibleColumns = table.getVisibleLeafColumns();
 
 	// The virtualizers need to know the scrollable container element
@@ -54,6 +60,7 @@ export const TableContainer = ({ table }: { table: Table<TableRecord> }) => {
 				<TableBody
 					columnVirtualizer={columnVirtualizer}
 					table={table}
+					tableName={tableName}
 					tableContainerRef={tableContainerRef as RefObject<HTMLDivElement>}
 					virtualPaddingLeft={virtualPaddingLeft as number | undefined}
 					virtualPaddingRight={virtualPaddingRight}

--- a/packages/web/src/features/tables/components/table-grid.tsx
+++ b/packages/web/src/features/tables/components/table-grid.tsx
@@ -22,7 +22,10 @@ export const TableGrid = ({
 			setRowSelection={setRowSelection}
 			tableName={tableName}
 		/>
-		<TableContainer table={table} />
+		<TableContainer
+			table={table}
+			tableName={tableName}
+		/>
 		<TableFooter tableName={tableName} />
 	</div>
 );

--- a/packages/web/src/features/tables/components/table-tab-container.test.tsx
+++ b/packages/web/src/features/tables/components/table-tab-container.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useOverlayStore } from "@/stores/overlay.store";
+import { useRowDetailsStore } from "../stores/row-details.store";
+import { TableTabContainer } from "./table-tab-container";
+
+const fixtures = vi.hoisted(() => ({
+	cols: [
+		{
+			columnName: "id",
+			dataType: "number",
+			dataTypeLabel: "int",
+			isNullable: false,
+			columnDefault: "nextval('users_id_seq'::regclass)",
+			isPrimaryKey: true,
+			isForeignKey: false,
+			referencedTable: null,
+			referencedColumn: null,
+			enumValues: null,
+		},
+		{
+			columnName: "name",
+			dataType: "text",
+			dataTypeLabel: "text",
+			isNullable: true,
+			columnDefault: null,
+			isPrimaryKey: false,
+			isForeignKey: false,
+			referencedTable: null,
+			referencedColumn: null,
+			enumValues: null,
+		},
+	],
+	gridRows: [{ original: { id: 1, name: "Ada" } }, { original: { id: 2, name: "Bob" } }],
+	// Mirrors useReactTable: a stable instance whose row model resolves live.
+	table: {} as { getRowModel: () => { rows: Array<{ original: Record<string, unknown> }> } },
+	updateRecord: vi.fn(async () => "Updated 1 record"),
+	deleteCells: vi.fn(async () => ({ deletedCount: 1 })),
+}));
+
+fixtures.table = {
+	getRowModel: () => ({ rows: fixtures.gridRows }),
+};
+
+vi.mock("../hooks/use-table-data", () => ({
+	useTableData: () => ({
+		tableData: { data: [{ id: 1 }, { id: 2 }] },
+		isLoadingTableData: false,
+		errorTableData: null,
+	}),
+}));
+vi.mock("@/features/schema", () => ({
+	useTableCols: () => ({
+		tableCols: fixtures.cols,
+		isLoadingTableCols: false,
+		errorTableCols: null,
+	}),
+}));
+vi.mock("../hooks/use-table-model", () => ({
+	useTableModel: () => ({
+		table: fixtures.table,
+		selectedRows: [],
+		setRowSelection: vi.fn(),
+	}),
+}));
+vi.mock("./table-grid", () => ({
+	TableGrid: () => null,
+}));
+vi.mock("@/stores/database.store", () => ({
+	useDatabaseStore: () => ({ dbType: "pg" }),
+}));
+vi.mock("@/features/tables/hooks/use-update-record", () => ({
+	useUpdateRecord: () => ({
+		updateRecord: fixtures.updateRecord,
+		isUpdatingRecord: false,
+	}),
+}));
+vi.mock("@/features/tables/hooks/use-delete-cell", () => ({
+	useDeleteCells: () => ({
+		deleteCells: fixtures.deleteCells,
+		isDeletingCells: false,
+	}),
+}));
+vi.mock("@/features/records", async (importOriginal) => {
+	const mod = await importOriginal<typeof import("@/features/records")>();
+	return { ...mod, RecordReferenceSheet: () => null };
+});
+vi.mock("nuqs", () => ({
+	useQueryState: () => [null, vi.fn()],
+}));
+
+describe("TableTabContainer row details wiring", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		fixtures.gridRows = [
+			{ original: { id: 1, name: "Ada" } },
+			{ original: { id: 2, name: "Bob" } },
+		];
+		useOverlayStore.setState({ openOverlays: [] });
+		useRowDetailsStore.setState({ tableName: null, rowIndex: null });
+	});
+
+	it("feeds refreshed row-model output to the sheet, not a stale memo", async () => {
+		useOverlayStore.getState().openOverlay("tables.row-details");
+		useRowDetailsStore.getState().setRowDetails("users", 0);
+		const { rerender } = render(<TableTabContainer tableName="users" />);
+
+		expect(await screen.findByDisplayValue("Ada")).toBeInTheDocument();
+		expect(screen.getByRole("group", { name: "id" })).toHaveTextContent("1");
+
+		// Simulate a sorted/refreshed row model behind the open sheet.
+		fixtures.gridRows = [
+			{ original: { id: 2, name: "Bob" } },
+			{ original: { id: 1, name: "Ada" } },
+		];
+		rerender(<TableTabContainer tableName="users" />);
+
+		// Read-only cells follow the live row; the draft keeps its values.
+		expect(await screen.findByText("2")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("Ada")).toBeInTheDocument();
+	});
+});

--- a/packages/web/src/features/tables/components/table-tab-container.test.tsx
+++ b/packages/web/src/features/tables/components/table-tab-container.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useOverlayStore } from "@/stores/overlay.store";
 import { useRowDetailsStore } from "../stores/row-details.store";
@@ -115,8 +116,29 @@ describe("TableTabContainer row details wiring", () => {
 		];
 		rerender(<TableTabContainer tableName="users" />);
 
-		// Read-only cells follow the live row; the draft keeps its values.
+		// Untouched drafts update all displayed fields to follow the refreshed row.
 		expect(await screen.findByText("2")).toBeInTheDocument();
-		expect(screen.getByDisplayValue("Ada")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("Bob")).toBeInTheDocument();
+	});
+
+	it("preserves dirty field values when the refreshed row has the same stable record identity", async () => {
+		useOverlayStore.getState().openOverlay("tables.row-details");
+		useRowDetailsStore.getState().setRowDetails("users", 0);
+		const user = userEvent.setup();
+		const { rerender } = render(<TableTabContainer tableName="users" />);
+
+		const nameInput = await screen.findByDisplayValue("Ada");
+		await user.clear(nameInput);
+		await user.type(nameInput, "Grace");
+
+		// Simulate background data refresh for the same record (id: 1)
+		fixtures.gridRows = [
+			{ original: { id: 1, name: "Ada" } },
+			{ original: { id: 2, name: "Bob" } },
+		];
+		rerender(<TableTabContainer tableName="users" />);
+
+		expect(screen.getByRole("group", { name: "id" })).toHaveTextContent("1");
+		expect(screen.getByDisplayValue("Grace")).toBeInTheDocument();
 	});
 });

--- a/packages/web/src/features/tables/components/table-tab-container.tsx
+++ b/packages/web/src/features/tables/components/table-tab-container.tsx
@@ -1,9 +1,12 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useTableCols } from "@/features/schema";
 import { useDatabaseStore } from "@/stores/database.store";
+import { useOverlayStore } from "@/stores/overlay.store";
 import type { TableRecord } from "@/types/table.type";
 import { useTableData } from "../hooks/use-table-data";
 import { useTableModel } from "../hooks/use-table-model";
+import { useRowDetailsStore } from "../stores/row-details.store";
+import { RowDetailsSheet } from "./row-details-sheet";
 import { TableDocumentView } from "./table-document-view";
 import { TableEmptyState } from "./table-empty-state";
 import { TableErrorState } from "./table-error-state";
@@ -26,6 +29,21 @@ export const TableTabContainer = ({ tableName }: { tableName: string }) => {
 		tableCols,
 		tableDataRows,
 	});
+
+	// Visible-order rows for the details sheet. Memoized so the sheet does
+	// not re-render on every grid render.
+	const visibleRows = useMemo(
+		() => table.getRowModel().rows.map((gridRow) => gridRow.original),
+		[table],
+	);
+
+	// A stale selection must never survive a table switch or unmount.
+	useEffect(() => {
+		return () => {
+			useRowDetailsStore.getState().clearRowDetails();
+			useOverlayStore.getState().closeOverlay("tables.row-details");
+		};
+	}, [tableName]);
 
 	if (isLoadingTableData || isLoadingTableCols) {
 		return <TableLoadingState />;
@@ -64,11 +82,17 @@ export const TableTabContainer = ({ tableName }: { tableName: string }) => {
 	}
 
 	return (
-		<TableGrid
-			table={table}
-			tableName={tableName}
-			selectedRows={selectedRows}
-			setRowSelection={setRowSelection}
-		/>
+		<>
+			<TableGrid
+				table={table}
+				tableName={tableName}
+				selectedRows={selectedRows}
+				setRowSelection={setRowSelection}
+			/>
+			<RowDetailsSheet
+				tableName={tableName}
+				rows={visibleRows}
+			/>
+		</>
 	);
 };

--- a/packages/web/src/features/tables/components/table-tab-container.tsx
+++ b/packages/web/src/features/tables/components/table-tab-container.tsx
@@ -30,11 +30,13 @@ export const TableTabContainer = ({ tableName }: { tableName: string }) => {
 		tableDataRows,
 	});
 
-	// Visible-order rows for the details sheet. Memoized so the sheet does
-	// not re-render on every grid render.
+	// Visible-order rows for the details sheet. useReactTable keeps a stable
+	// table instance (setOptions per render), so the memo must key on the
+	// row-model output itself, not the table, or the sheet keeps stale rows.
+	const rowModel = table.getRowModel();
 	const visibleRows = useMemo(
-		() => table.getRowModel().rows.map((gridRow) => gridRow.original),
-		[table],
+		() => rowModel.rows.map((gridRow) => gridRow.original),
+		[rowModel],
 	);
 
 	// A stale selection must never survive a table switch or unmount.

--- a/packages/web/src/features/tables/hooks/use-delayed-row-open.test.ts
+++ b/packages/web/src/features/tables/hooks/use-delayed-row-open.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ROW_DETAILS_OPEN_DELAY, useDelayedRowOpen } from "./use-delayed-row-open";
+
+describe("useDelayedRowOpen", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("runs the action after the delay", () => {
+		const action = vi.fn();
+		const { result } = renderHook(() => useDelayedRowOpen());
+
+		act(() => {
+			result.current.schedule(action);
+		});
+		expect(action).not.toHaveBeenCalled();
+
+		act(() => {
+			vi.advanceTimersByTime(ROW_DETAILS_OPEN_DELAY);
+		});
+		expect(action).toHaveBeenCalledTimes(1);
+	});
+
+	it("cancels a pending action on double-click", () => {
+		const action = vi.fn();
+		const { result } = renderHook(() => useDelayedRowOpen());
+
+		act(() => {
+			result.current.schedule(action);
+			result.current.cancel();
+			vi.advanceTimersByTime(ROW_DETAILS_OPEN_DELAY);
+		});
+		expect(action).not.toHaveBeenCalled();
+	});
+
+	it("restarts the delay when scheduled twice", () => {
+		const action = vi.fn();
+		const { result } = renderHook(() => useDelayedRowOpen());
+
+		act(() => {
+			result.current.schedule(action);
+			vi.advanceTimersByTime(ROW_DETAILS_OPEN_DELAY - 50);
+			result.current.schedule(action);
+			vi.advanceTimersByTime(ROW_DETAILS_OPEN_DELAY - 50);
+		});
+		expect(action).not.toHaveBeenCalled();
+
+		act(() => {
+			vi.advanceTimersByTime(50);
+		});
+		expect(action).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/web/src/features/tables/hooks/use-delayed-row-open.ts
+++ b/packages/web/src/features/tables/hooks/use-delayed-row-open.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export const ROW_DETAILS_OPEN_DELAY = 250;
+
+// Delays an action so a double-click can cancel it first. The row grid uses
+// this to open the details sheet on single-click without stealing the
+// double-click that starts inline cell editing.
+export const useDelayedRowOpen = (delay: number = ROW_DETAILS_OPEN_DELAY) => {
+	const timerRef = useRef<number | null>(null);
+
+	useEffect(
+		() => () => {
+			if (timerRef.current !== null) {
+				window.clearTimeout(timerRef.current);
+			}
+		},
+		[],
+	);
+
+	const schedule = useCallback(
+		(action: () => void) => {
+			if (timerRef.current !== null) {
+				window.clearTimeout(timerRef.current);
+			}
+			timerRef.current = window.setTimeout(() => {
+				timerRef.current = null;
+				action();
+			}, delay);
+		},
+		[delay],
+	);
+
+	const cancel = useCallback(() => {
+		if (timerRef.current !== null) {
+			window.clearTimeout(timerRef.current);
+			timerRef.current = null;
+		}
+	}, []);
+
+	return { schedule, cancel };
+};

--- a/packages/web/src/features/tables/hooks/use-update-record.test.tsx
+++ b/packages/web/src/features/tables/hooks/use-update-record.test.tsx
@@ -81,4 +81,20 @@ describe("useUpdateRecord", () => {
 		).rejects.toThrow("At least one field is required");
 		expect(updateRecords).not.toHaveBeenCalled();
 	});
+
+	it("propagates api failures to the caller instead of the toast id", async () => {
+		updateRecords.mockRejectedValue(new Error("boom"));
+		const { wrapper } = createWrapper();
+		const { result } = renderHook(() => useUpdateRecord({ tableName: "users" }), {
+			wrapper,
+		});
+
+		await expect(
+			result.current.updateRecord({
+				rowData: { id: 1 },
+				updates: [{ columnName: "name", value: "Grace" }],
+				primaryKey: "id",
+			}),
+		).rejects.toThrow("boom");
+	});
 });

--- a/packages/web/src/features/tables/hooks/use-update-record.test.tsx
+++ b/packages/web/src/features/tables/hooks/use-update-record.test.tsx
@@ -1,0 +1,84 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDatabaseStore } from "@/stores/database.store";
+import { useUpdateRecord } from "./use-update-record";
+
+const updateRecords = vi.hoisted(() => vi.fn());
+
+vi.mock("@/shared/api", () => ({
+	updateRecords: (...args: unknown[]) => updateRecords(...args),
+}));
+
+const createWrapper = () => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+	return { wrapper, invalidateSpy };
+};
+
+describe("useUpdateRecord", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		useDatabaseStore.setState({ selectedDatabase: "shop", dbType: "pg" });
+		updateRecords.mockResolvedValue({ data: { data: "Updated 1 record" } });
+	});
+
+	it("sends one save with the resolved primary key", async () => {
+		const { wrapper, invalidateSpy } = createWrapper();
+		const { result } = renderHook(() => useUpdateRecord({ tableName: "users" }), {
+			wrapper,
+		});
+
+		await result.current.updateRecord({
+			rowData: { id: 1, name: "Ada" },
+			updates: [{ columnName: "name", value: "Grace" }],
+			primaryKey: "id",
+		});
+
+		expect(updateRecords).toHaveBeenCalledWith({
+			tableName: "users",
+			updates: [{ rowData: { id: 1, name: "Ada" }, columnName: "name", value: "Grace" }],
+			primaryKey: "id",
+			db: "shop",
+		});
+		await waitFor(() => {
+			expect(invalidateSpy).toHaveBeenCalled();
+		});
+	});
+
+	it("omits the primary key when the table has none", async () => {
+		const { wrapper } = createWrapper();
+		const { result } = renderHook(() => useUpdateRecord({ tableName: "logs" }), {
+			wrapper,
+		});
+
+		await result.current.updateRecord({
+			rowData: { message: "hi" },
+			updates: [{ columnName: "message", value: "hello" }],
+		});
+
+		expect(updateRecords).toHaveBeenCalledWith({
+			tableName: "logs",
+			updates: [{ rowData: { message: "hi" }, columnName: "message", value: "hello" }],
+			db: "shop",
+		});
+	});
+
+	it("rejects empty updates without calling the api", async () => {
+		const { wrapper } = createWrapper();
+		const { result } = renderHook(() => useUpdateRecord({ tableName: "users" }), {
+			wrapper,
+		});
+
+		await expect(
+			result.current.updateRecord({ rowData: { id: 1 }, updates: [] }),
+		).rejects.toThrow("At least one field is required");
+		expect(updateRecords).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/features/tables/hooks/use-update-record.ts
+++ b/packages/web/src/features/tables/hooks/use-update-record.ts
@@ -64,16 +64,13 @@ export const useUpdateRecord = ({ tableName }: { tableName: string }) => {
 		if (updates.length === 0) {
 			throw new Error("At least one field is required");
 		}
-		// toast.promise resolves with the toast id even on failure, so it
-		// cannot be the caller's promise. Display through it, but return the
-		// raw mutation promise so failures propagate to the caller's catch.
-		const pending = updateRecordMutation({ rowData, updates, primaryKey });
-		toast.promise(pending, {
-			loading: "Saving changes...",
-			success: (message) => message || "Record updated successfully",
-			error: (error: Error) => error.message || "Failed to update record",
-		});
-		return pending;
+		return toast
+			.promise(updateRecordMutation({ rowData, updates, primaryKey }), {
+				loading: "Saving changes...",
+				success: (message) => message || "Record updated successfully",
+				error: (error: Error) => error.message || "Failed to update record",
+			})
+			.unwrap();
 	};
 
 	return {

--- a/packages/web/src/features/tables/hooks/use-update-record.ts
+++ b/packages/web/src/features/tables/hooks/use-update-record.ts
@@ -1,0 +1,78 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { posthogAnalytics } from "@/lib/posthog";
+import { updateRecords } from "@/shared/api";
+import { tableKeys } from "@/shared/query/keys";
+import { useDatabaseStore } from "@/stores/database.store";
+
+export type RowFieldUpdate = {
+	columnName: string;
+	value: unknown;
+};
+
+export const useUpdateRecord = ({ tableName }: { tableName: string }) => {
+	const queryClient = useQueryClient();
+	const { selectedDatabase, dbType } = useDatabaseStore();
+
+	const { mutateAsync: updateRecordMutation, isPending: isUpdatingRecord } = useMutation({
+		mutationFn: async ({
+			rowData,
+			updates,
+			primaryKey,
+		}: {
+			rowData: Record<string, unknown>;
+			updates: RowFieldUpdate[];
+			primaryKey?: string;
+		}) => {
+			if (!tableName) {
+				throw new Error("No table selected");
+			}
+			if (updates.length === 0) {
+				throw new Error("At least one field is required");
+			}
+			const res = await updateRecords({
+				tableName,
+				updates: updates.map((update) => ({ rowData, ...update })),
+				...(primaryKey ? { primaryKey } : {}),
+				db: selectedDatabase,
+			});
+			return res.data.data;
+		},
+		onSuccess: async () => {
+			await Promise.all([
+				queryClient.invalidateQueries({
+					queryKey: tableKeys.dataByTable(tableName),
+					exact: false,
+				}),
+				queryClient.invalidateQueries({
+					queryKey: tableKeys.lists(),
+				}),
+			]);
+			if (dbType) posthogAnalytics.capture("record_updated", { db_type: dbType });
+		},
+	});
+
+	const updateRecord = async ({
+		rowData,
+		updates,
+		primaryKey,
+	}: {
+		rowData: Record<string, unknown>;
+		updates: RowFieldUpdate[];
+		primaryKey?: string;
+	}) => {
+		if (updates.length === 0) {
+			throw new Error("At least one field is required");
+		}
+		return toast.promise(updateRecordMutation({ rowData, updates, primaryKey }), {
+			loading: "Saving changes...",
+			success: (message) => message || "Record updated successfully",
+			error: (error: Error) => error.message || "Failed to update record",
+		});
+	};
+
+	return {
+		updateRecord,
+		isUpdatingRecord,
+	};
+};

--- a/packages/web/src/features/tables/hooks/use-update-record.ts
+++ b/packages/web/src/features/tables/hooks/use-update-record.ts
@@ -64,11 +64,16 @@ export const useUpdateRecord = ({ tableName }: { tableName: string }) => {
 		if (updates.length === 0) {
 			throw new Error("At least one field is required");
 		}
-		return toast.promise(updateRecordMutation({ rowData, updates, primaryKey }), {
+		// toast.promise resolves with the toast id even on failure, so it
+		// cannot be the caller's promise. Display through it, but return the
+		// raw mutation promise so failures propagate to the caller's catch.
+		const pending = updateRecordMutation({ rowData, updates, primaryKey });
+		toast.promise(pending, {
 			loading: "Saving changes...",
 			success: (message) => message || "Record updated successfully",
 			error: (error: Error) => error.message || "Failed to update record",
 		});
+		return pending;
 	};
 
 	return {

--- a/packages/web/src/features/tables/stores/row-details.store.test.ts
+++ b/packages/web/src/features/tables/stores/row-details.store.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useRowDetailsStore } from "./row-details.store";
+
+const state = () => useRowDetailsStore.getState();
+
+beforeEach(() => {
+	useRowDetailsStore.setState({ tableName: null, rowIndex: null });
+});
+
+describe("useRowDetailsStore", () => {
+	it("starts with no selection", () => {
+		expect(state().tableName).toBeNull();
+		expect(state().rowIndex).toBeNull();
+	});
+
+	it("stores the selected table and row", () => {
+		state().setRowDetails("users", 2);
+		expect(state().tableName).toBe("users");
+		expect(state().rowIndex).toBe(2);
+	});
+
+	it("moves the selection without changing the table", () => {
+		state().setRowDetails("users", 0);
+		state().selectRowDetails(4);
+		expect(state().tableName).toBe("users");
+		expect(state().rowIndex).toBe(4);
+	});
+
+	it("clears the selection", () => {
+		state().setRowDetails("users", 1);
+		state().clearRowDetails();
+		expect(state().tableName).toBeNull();
+		expect(state().rowIndex).toBeNull();
+	});
+});

--- a/packages/web/src/features/tables/stores/row-details.store.ts
+++ b/packages/web/src/features/tables/stores/row-details.store.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+
+type RowDetailsStore = {
+	tableName: string | null;
+	rowIndex: number | null;
+	setRowDetails: (tableName: string, rowIndex: number) => void;
+	selectRowDetails: (rowIndex: number) => void;
+	clearRowDetails: () => void;
+};
+
+export const useRowDetailsStore = create<RowDetailsStore>()((set) => ({
+	tableName: null,
+	rowIndex: null,
+
+	setRowDetails: (tableName, rowIndex) => set({ tableName, rowIndex }),
+
+	selectRowDetails: (rowIndex) => set({ rowIndex }),
+
+	clearRowDetails: () => set({ tableName: null, rowIndex: null }),
+}));

--- a/packages/web/src/lib/posthog.ts
+++ b/packages/web/src/lib/posthog.ts
@@ -8,6 +8,7 @@ type AnalyticsEvent =
 	| { event: "db_selected"; properties: { db_type: DatabaseTypeSchema } }
 	| { event: "query_executed"; properties: { db_type: DatabaseTypeSchema } }
 	| { event: "record_created"; properties: { db_type: DatabaseTypeSchema } }
+	| { event: "record_updated"; properties: { db_type: DatabaseTypeSchema } }
 	| { event: "record_deleted"; properties: { db_type: DatabaseTypeSchema } }
 	| { event: "record_exported"; properties: { db_type: DatabaseTypeSchema; format: string } }
 	| { event: "table_created"; properties: { db_type: DatabaseTypeSchema } }

--- a/packages/web/src/shared/api/records.ts
+++ b/packages/web/src/shared/api/records.ts
@@ -25,6 +25,7 @@ export const createRecord = ({
 export const updateRecords = ({
 	tableName,
 	updates,
+	primaryKey,
 	db,
 }: {
 	tableName: string;
@@ -33,11 +34,12 @@ export const updateRecords = ({
 		columnName: string;
 		value: unknown;
 	}>;
+	primaryKey?: string;
 	db?: string | null;
 }) =>
 	api.patch<BaseResponse<string>>(
 		"/records",
-		{ tableName, updates },
+		{ tableName, updates, ...(primaryKey ? { primaryKey } : {}) },
 		{ params: { db: db ?? "" } },
 	);
 

--- a/packages/web/src/stores/overlay.store.test.ts
+++ b/packages/web/src/stores/overlay.store.test.ts
@@ -85,6 +85,14 @@ describe("useOverlayStore", () => {
 			expect(state().isOverlayOpen("chat.assistant")).toBe(true);
 		});
 
+		it("stacks the row details sheet below nested overlays", () => {
+			state().openOverlay("tables.row-details");
+			state().openOverlay("records.record-reference");
+			expect(state().openOverlays).toEqual(["tables.row-details", "records.record-reference"]);
+			state().closeOverlay("records.record-reference");
+			expect(state().openOverlays).toEqual(["tables.row-details"]);
+		});
+
 		it("getOverlayIndex returns the stack position, -1 when absent", () => {
 			state().openOverlay("records.add-record");
 			state().openOverlay("records.bulk-insert");

--- a/packages/web/src/stores/overlay.store.ts
+++ b/packages/web/src/stores/overlay.store.ts
@@ -11,6 +11,7 @@ export type OverlayId =
 	| "records.bulk-insert-excel"
 	| "records.bulk-insert-json"
 	| "records.record-reference"
+	| "tables.row-details"
 	| "redis-browser.create-key"
 	| "settings.app"
 	| "chat.assistant";


### PR DESCRIPTION
Closes #269.

Single-clicking ordinary row content now opens a details sheet with every field as a label/value pair. It reuses the type-aware record editors, saves all dirty fields through one action, asks before changing a primary key, guards unsaved changes on close, navigation, and delete, and supports prev/next chevrons plus Up/Down keys. Double-click still opens inline editing, and copy buttons, checkboxes, links, and editor surfaces never trigger the sheet.

Verified with `bun run typecheck`, `bun run test` (131 passed, 34 new), and Biome check in packages/web.

Follow-ups worth tracking: a trigger for MongoDB's document view (this covers the table grid), and surfacing FK violations from the shared delete hook so both the grid and the sheet can offer force-delete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a row-details sheet for viewing and editing table records.
  - Added inline field editing, copy-to-clipboard, row navigation, record deletion, and confirmation prompts.
  - Added row-click access to record details while preserving double-click behavior.
  - Added accessible names for controls and optional hidden field labels.
  - Generated primary-key fields are now read-only.

- **Bug Fixes**
  - Improved unsaved-change protection, update error handling, navigation, and draft synchronization.

- **Tests**
  - Added coverage for editing, accessibility, updates, navigation, confirmations, and overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->