### PR TITLE
test(back): enforce coverage thresholds in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -66,5 +66,8 @@ jobs:
       - name: Install dependencies
         run: bun install --ignore-scripts
 
-      - name: Run Tests
-        run: bun run test
+      - name: Run Web Tests
+        run: bun run test --filter=@db-studio/web
+
+      - name: Run Server Tests with Coverage
+        run: bun run --cwd packages/server test:coverage

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
 			reporter: ["text", "json", "html"],
 			include: ["src/**/*.ts"],
 			exclude: ["src/**/*.test.ts", "src/index.ts", "src/cmd/**"],
+			// Floor of measured coverage per #276 — raise with new tests, never lower to green.
+			thresholds: {
+				lines: 76,
+				branches: 64,
+				functions: 72,
+				statements: 74,
+			},
 		},
 		setupFiles: ["./tests/setup.ts"],
 	},


### PR DESCRIPTION
Sets floor coverage thresholds in the server vitest config and runs them in CI, so a silent coverage drop now fails the build.

Thresholds are floor(measured): lines 76, branches 64, functions 72, statements 74. The test-server job splits web tests from a direct server coverage run that exits non-zero below threshold. Verified the gate once by bumping lines to 99 (failed as expected) then reverted.

Closes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Web and server tests now run as separate validation steps.
  * Server test runs include coverage reporting.
  * Minimum coverage thresholds are now enforced for lines, branches, functions, and statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->