### PR TITLE
feat(tables): add column visibility and reorder preferences (#271)

### DIFF
--- a/packages/web/src/features/tables/components/header/column-preferences-menu.test.tsx
+++ b/packages/web/src/features/tables/components/header/column-preferences-menu.test.tsx
@@ -1,0 +1,168 @@
+import "@testing-library/jest-dom/vitest";
+import type { ColumnInfoSchemaType } from "@db-studio/shared/types";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadColumnPrefs, saveColumnPrefs } from "../../stores/column-preferences.store";
+import { ColumnPreferencesMenu } from "./column-preferences-menu";
+
+const parts = { dbType: "pg", database: "dbstudio", tableName: "users" };
+
+const makeCol = (columnName: string, isPrimaryKey = false): ColumnInfoSchemaType => ({
+	columnName,
+	dataType: "text",
+	dataTypeLabel: "text",
+	isNullable: !isPrimaryKey,
+	columnDefault: null,
+	isPrimaryKey,
+	isForeignKey: false,
+	referencedTable: null,
+	referencedColumn: null,
+	enumValues: null,
+});
+
+vi.mock("@/features/schema", () => ({
+	useTableCols: ({ tableName }: { tableName: string }) => ({
+		tableCols:
+			tableName === "users"
+				? [makeCol("id", true), makeCol("name", false), makeCol("email", false)]
+				: undefined,
+	}),
+}));
+
+vi.mock("@/stores/database.store", () => ({
+	useDatabaseStore: () => ({ dbType: "pg", selectedDatabase: "dbstudio" }),
+}));
+
+const openMenu = async () => {
+	fireEvent.click(screen.getByRole("button", { name: "Manage columns" }));
+	await screen.findByText("Columns");
+};
+
+beforeEach(() => {
+	localStorage.clear();
+});
+
+describe("ColumnPreferencesMenu", () => {
+	it("lists every database column and no utility columns", async () => {
+		render(<ColumnPreferencesMenu tableName="users" />);
+		await openMenu();
+		expect(screen.getByText("id")).toBeInTheDocument();
+		expect(screen.getByText("name")).toBeInTheDocument();
+		expect(screen.getByText("email")).toBeInTheDocument();
+		expect(screen.queryByText("select")).not.toBeInTheDocument();
+		expect(screen.queryByText("__row_actions")).not.toBeInTheDocument();
+	});
+
+	it("shows the count of visible columns", async () => {
+		render(<ColumnPreferencesMenu tableName="users" />);
+		await openMenu();
+		expect(screen.getByText("3/3 shown")).toBeInTheDocument();
+	});
+
+	it("search filters the menu without changing the table", async () => {
+		render(<ColumnPreferencesMenu tableName="users" />);
+		await openMenu();
+		fireEvent.change(screen.getByLabelText("Search columns"), {
+			target: { value: "em" },
+		});
+		expect(screen.getByText("email")).toBeInTheDocument();
+		expect(screen.queryByText("id")).not.toBeInTheDocument();
+		// the table itself stays untouched by search — hidden set is unchanged
+		expect(loadColumnPrefs(parts).hidden).toEqual([]);
+	});
+
+	it("toggling visibility persists and updates the count", async () => {
+		render(<ColumnPreferencesMenu tableName="users" />);
+		await openMenu();
+		fireEvent.click(screen.getByLabelText("Show name"));
+		await waitFor(() => {
+			expect(loadColumnPrefs(parts).hidden).toEqual(["name"]);
+		});
+		expect(screen.getByText("2/3 shown")).toBeInTheDocument();
+	});
+
+	it("search matches case-insensitively", async () => {
+		render(<ColumnPreferencesMenu tableName="users" />);
+		await openMenu();
+		fireEvent.change(screen.getByLabelText("Search columns"), {
+			target: { value: "EMAIL" },
+		});
+		expect(screen.getByText("email")).toBeInTheDocument();
+		expect(screen.queryByText("name")).not.toBeInTheDocument();
+	});
+
+	it("keeps saved hidden state when reopening", async () => {
+		saveColumnPrefs(parts, { order: [], hidden: ["email"] });
+		render(<ColumnPreferencesMenu tableName="users" />);
+		await openMenu();
+		expect(screen.getByText("2/3 shown")).toBeInTheDocument();
+	});
+
+	it("show all makes every column visible while keeping custom order", async () => {
+		saveColumnPrefs(parts, {
+			order: ["email", "name", "id"],
+			hidden: ["email", "name"],
+		});
+		render(<ColumnPreferencesMenu tableName="users" />);
+		await openMenu();
+		expect(screen.getByText("1/3 shown")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Show all" }));
+		await waitFor(() => {
+			const saved = loadColumnPrefs(parts);
+			expect(saved.hidden).toEqual([]);
+			expect(saved.order).toEqual(["email", "name", "id"]);
+		});
+		expect(screen.getByText("3/3 shown")).toBeInTheDocument();
+	});
+
+	it("reset restores schema order and default visibility", async () => {
+		saveColumnPrefs(parts, { order: ["email", "name", "id"], hidden: ["name"] });
+		render(<ColumnPreferencesMenu tableName="users" />);
+		await openMenu();
+		fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+		await waitFor(() => {
+			expect(loadColumnPrefs(parts)).toEqual({ order: [], hidden: [] });
+		});
+		expect(screen.getByText("3/3 shown")).toBeInTheDocument();
+	});
+
+	it("keyboard users can reorder columns with ArrowUp and ArrowDown", async () => {
+		render(<ColumnPreferencesMenu tableName="users" />);
+		await openMenu();
+		const emailHandle = screen.getByRole("button", { name: "Reorder email" });
+		fireEvent.keyDown(emailHandle, { key: "ArrowUp" });
+		await waitFor(() => {
+			expect(loadColumnPrefs(parts).order).toEqual(["id", "email", "name"]);
+		});
+		fireEvent.keyDown(emailHandle, { key: "ArrowDown" });
+		await waitFor(() => {
+			expect(loadColumnPrefs(parts).order).toEqual(["id", "name", "email"]);
+		});
+	});
+
+	it("drag and drop reorders columns immediately", async () => {
+		render(<ColumnPreferencesMenu tableName="users" />);
+		await openMenu();
+		const items = screen.getAllByRole("listitem");
+		// Drag email (index 2) onto id (index 0)
+		fireEvent.dragStart(items[2]);
+		fireEvent.drop(items[0]);
+		await waitFor(() => {
+			expect(loadColumnPrefs(parts).order).toEqual(["email", "id", "name"]);
+		});
+	});
+
+	it("reordering works safely even when search filter is active", async () => {
+		render(<ColumnPreferencesMenu tableName="users" />);
+		await openMenu();
+		// Filter to only 'name' and 'email' (hiding 'id')
+		fireEvent.change(screen.getByLabelText("Search columns"), {
+			target: { value: "m" },
+		});
+		const emailHandle = screen.getByRole("button", { name: "Reorder email" });
+		fireEvent.keyDown(emailHandle, { key: "ArrowUp" });
+		await waitFor(() => {
+			expect(loadColumnPrefs(parts).order).toEqual(["id", "email", "name"]);
+		});
+	});
+});

--- a/packages/web/src/features/tables/components/header/column-preferences-menu.tsx
+++ b/packages/web/src/features/tables/components/header/column-preferences-menu.tsx
@@ -1,0 +1,216 @@
+import { Button } from "@db-studio/ui/button";
+import { Checkbox } from "@db-studio/ui/checkbox";
+import { Popover, PopoverContent, PopoverTrigger } from "@db-studio/ui/popover";
+import { Separator } from "@db-studio/ui/separator";
+import { cn } from "@db-studio/ui/utils";
+import {
+	CheckCheck,
+	ChevronDown,
+	ChevronUp,
+	GripVertical,
+	RotateCcw,
+	Search,
+	Settings2,
+} from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { useTableCols } from "@/features/schema";
+import { useColumnPreferences } from "../../hooks/use-column-preferences";
+
+interface ColumnPreferencesMenuProps {
+	tableName: string;
+}
+
+export const ColumnPreferencesMenu = ({ tableName }: ColumnPreferencesMenuProps) => {
+	const [search, setSearch] = useState("");
+	const [dragIndex, setDragIndex] = useState<number | null>(null);
+	const searchRef = useRef<HTMLInputElement>(null);
+
+	const { tableCols } = useTableCols({ tableName });
+
+	const {
+		orderedColumns,
+		visibleColumns,
+		toggleColumn,
+		moveColumn,
+		reorderColumn,
+		showAllColumns,
+		resetColumns,
+	} = useColumnPreferences({ tableName, tableCols });
+
+	// menu rows follow the currently saved order, so drag-and-drop reads naturally
+	const filtered = useMemo(() => {
+		const q = search.trim().toLowerCase();
+		if (!q) return orderedColumns;
+		return orderedColumns.filter((name) => name.toLowerCase().includes(q));
+	}, [orderedColumns, search]);
+
+	const visibleSet = useMemo(() => new Set(visibleColumns), [visibleColumns]);
+	const totalCount = tableCols?.length ?? 0;
+	const hiddenCount = totalCount - visibleColumns.length;
+	const isCustomized =
+		hiddenCount > 0 ||
+		orderedColumns.some((name, i) => (tableCols ?? [])[i]?.columnName !== name);
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<Button
+					type="button"
+					variant="ghost"
+					className={cn(
+						"size-8! aspect-square border-l-0 border-y-0 border-r border-border rounded-none text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors",
+						isCustomized && "text-foreground",
+					)}
+					aria-label="Manage columns"
+					data-active={isCustomized}
+				>
+					<Settings2 className="size-4" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="start"
+				className="w-72 gap-0 p-0"
+				onOpenAutoFocus={(e) => {
+					e.preventDefault();
+					searchRef.current?.focus();
+				}}
+			>
+				<div
+					className="flex items-center justify-between px-2 py-1.5 text-sm font-medium"
+					role="heading"
+					aria-level={2}
+				>
+					<span>Columns</span>
+					<span className="text-xs font-normal text-muted-foreground">
+						{visibleColumns.length}/{totalCount} shown
+					</span>
+				</div>
+				<div className="relative px-2 pb-2">
+					<Search className="absolute left-4 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
+					<input
+						ref={searchRef}
+						type="text"
+						placeholder="Search columns..."
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						className="w-full h-8 pl-7 pr-2 text-sm bg-transparent rounded-md border border-border focus:outline-none focus:ring-1 focus:ring-ring"
+						aria-label="Search columns"
+					/>
+				</div>
+				<Separator className="my-0" />
+				<div
+					className="max-h-72 overflow-y-auto py-1"
+					role="list"
+					aria-label="Database columns"
+				>
+					{filtered.map((name, i) => {
+						const isVisible = visibleSet.has(name);
+						return (
+							<div
+								key={name}
+								role="listitem"
+								draggable
+								onDragStart={() => setDragIndex(i)}
+								onDragEnd={() => setDragIndex(null)}
+								onDragOver={(e) => e.preventDefault()}
+								onDrop={() => {
+									if (dragIndex !== null && dragIndex !== i) {
+										reorderColumn(filtered[dragIndex], filtered[i]);
+									}
+									setDragIndex(null);
+								}}
+								className={cn(
+									"group flex items-center gap-1.5 px-2 py-1 rounded-md",
+									dragIndex === i && "opacity-40",
+								)}
+							>
+								<span
+									role="button"
+									tabIndex={0}
+									aria-label={`Reorder ${name}`}
+									aria-roledescription="sortable"
+									title="Drag, or focus and press ArrowUp or ArrowDown to move"
+									className="cursor-grab active:cursor-grabbing text-muted-foreground/70 hover:text-muted-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-ring rounded-sm"
+									onKeyDown={(e) => {
+										if (e.key === "ArrowUp") {
+											e.preventDefault();
+											e.stopPropagation();
+											moveColumn(name, -1, filtered);
+										} else if (e.key === "ArrowDown") {
+											e.preventDefault();
+											e.stopPropagation();
+											moveColumn(name, 1, filtered);
+										}
+									}}
+								>
+									<GripVertical className="size-4" />
+								</span>
+								<Checkbox
+									checked={isVisible}
+									onCheckedChange={() => toggleColumn(name)}
+									aria-label={`Show ${name}`}
+								/>
+								<span
+									className="text-sm flex-1 cursor-pointer select-none truncate"
+									onClick={() => toggleColumn(name)}
+								>
+									{name}
+								</span>
+								<span className="flex flex-col opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+									<button
+										type="button"
+										tabIndex={0}
+										disabled={i === 0}
+										aria-label={`Move ${name} up`}
+										className="text-muted-foreground/70 hover:text-foreground disabled:opacity-30 disabled:pointer-events-none"
+										onClick={() => moveColumn(name, -1, filtered)}
+									>
+										<ChevronUp className="size-3.5" />
+									</button>
+									<button
+										type="button"
+										tabIndex={0}
+										disabled={i === filtered.length - 1}
+										aria-label={`Move ${name} down`}
+										className="text-muted-foreground/70 hover:text-foreground disabled:opacity-30 disabled:pointer-events-none"
+										onClick={() => moveColumn(name, 1, filtered)}
+									>
+										<ChevronDown className="size-3.5" />
+									</button>
+								</span>
+							</div>
+						);
+					})}
+					{filtered.length === 0 && (
+						<p className="text-sm text-muted-foreground text-center py-4 px-2">
+							No columns match &quot;{search}&quot;
+						</p>
+					)}
+				</div>
+				<Separator className="my-0" />
+				<div className="p-2 flex gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						className="flex-1 text-xs"
+						disabled={hiddenCount === 0}
+						onClick={showAllColumns}
+					>
+						<CheckCheck className="size-3.5" />
+						Show all
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						className="flex-1 text-xs"
+						disabled={!isCustomized}
+						onClick={resetColumns}
+					>
+						<RotateCcw className="size-3.5" />
+						Reset
+					</Button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+};

--- a/packages/web/src/features/tables/components/header/table-header.tsx
+++ b/packages/web/src/features/tables/components/header/table-header.tsx
@@ -3,6 +3,7 @@ import { useIsSchemaless } from "@/hooks/use-is-schemaless";
 import type { TableRecord } from "@/types/table.type";
 import { AddRecordMenu } from "./add-record-menu";
 import { ClearBtn } from "./clear-btn";
+import { ColumnPreferencesMenu } from "./column-preferences-menu";
 import { DeleteBtn } from "./delete-btn";
 import { FilterPopup } from "./filter-popup";
 import { RefetchBtn } from "./refetch-btn";
@@ -24,6 +25,7 @@ export const TableHeader = ({
 			<div className="flex items-center ">
 				<RefetchBtn tableName={tableName} />
 				{!isSchemaless && <FilterPopup tableName={tableName} />}
+				<ColumnPreferencesMenu tableName={tableName} />
 				<AddRecordMenu />
 				<SaveBtn setRowSelection={setRowSelection} />
 				<ClearBtn />

--- a/packages/web/src/features/tables/hooks/use-column-preferences.ts
+++ b/packages/web/src/features/tables/hooks/use-column-preferences.ts
@@ -1,5 +1,5 @@
 import type { ColumnInfoSchemaType } from "@db-studio/shared/types";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useDatabaseStore } from "@/stores/database.store";
 import {
 	applyColumnPrefs,
@@ -55,7 +55,9 @@ export const useColumnPreferences = ({
 	// `schemaKey` keeps this stable across re-renders that only change array
 	// identity; the no-op guard breaks any save→setPrefs→re-render cycle.
 	const schemaColsRef = useRef(schemaCols);
-	schemaColsRef.current = schemaCols;
+	useLayoutEffect(() => {
+		schemaColsRef.current = schemaCols;
+	}, [schemaCols]);
 	useEffect(() => {
 		if (schemaKey.length === 0) return;
 		const current = loadColumnPrefs(key);

--- a/packages/web/src/features/tables/hooks/use-column-preferences.ts
+++ b/packages/web/src/features/tables/hooks/use-column-preferences.ts
@@ -1,0 +1,165 @@
+import type { ColumnInfoSchemaType } from "@db-studio/shared/types";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useDatabaseStore } from "@/stores/database.store";
+import {
+	applyColumnPrefs,
+	type ColumnPrefs,
+	clearColumnPrefs,
+	loadColumnPrefs,
+	reconcileColumnPrefs,
+	reorderColumns,
+	sameColumnPrefKey,
+	sameColumnPrefs,
+	saveColumnPrefs,
+	subscribeColumnPrefsChanged,
+} from "../stores/column-preferences.store";
+
+export const useColumnPreferences = ({
+	tableName,
+	tableCols,
+}: {
+	tableName: string;
+	tableCols?: ColumnInfoSchemaType[];
+}) => {
+	const { dbType, selectedDatabase } = useDatabaseStore();
+
+	const schemaCols = useMemo(() => (tableCols ?? []).map((c) => c.columnName), [tableCols]);
+
+	// Content-based key: callers (or mocked hooks) may hand back a new array
+	// identity every render, so effect deps must never use `tableCols` directly.
+	const schemaKey = useMemo(() => schemaCols.join("\n"), [schemaCols]);
+
+	const key = useMemo(
+		() => ({ dbType: dbType ?? "", database: selectedDatabase ?? "", tableName }),
+		[dbType, selectedDatabase, tableName],
+	);
+
+	const [prefs, setPrefs] = useState<ColumnPrefs>(() => loadColumnPrefs(key));
+
+	// Re-read stored prefs whenever the scope (dbType/database/table) changes.
+	useEffect(() => {
+		setPrefs(loadColumnPrefs(key));
+	}, [key]);
+
+	// Stay in sync with writes from other useColumnPreferences instances
+	// (e.g. the menu) scoped to the same dbType/database/table.
+	useEffect(
+		() =>
+			subscribeColumnPrefsChanged((changed) => {
+				if (sameColumnPrefKey(changed, key)) setPrefs(loadColumnPrefs(key));
+			}),
+		[key],
+	);
+
+	// Reconcile on schema change: new columns appended, removed ones pruned.
+	// `schemaKey` keeps this stable across re-renders that only change array
+	// identity; the no-op guard breaks any save→setPrefs→re-render cycle.
+	const schemaColsRef = useRef(schemaCols);
+	schemaColsRef.current = schemaCols;
+	useEffect(() => {
+		if (schemaKey.length === 0) return;
+		const current = loadColumnPrefs(key);
+		const reconciled = reconcileColumnPrefs(schemaColsRef.current, current);
+		if (sameColumnPrefs(current, reconciled)) {
+			setPrefs((prev) => (sameColumnPrefs(prev, reconciled) ? prev : reconciled));
+			return;
+		}
+		saveColumnPrefs(key, reconciled);
+		setPrefs(reconciled);
+	}, [key, schemaKey]);
+
+	// Writes go through the same no-op guard: an update that reconciles to the
+	// current state does not notify subscribers or re-render.
+	const update = useCallback(
+		(next: ColumnPrefs) => {
+			const reconciled = reconcileColumnPrefs(schemaColsRef.current, next);
+			if (sameColumnPrefs(loadColumnPrefs(key), reconciled)) {
+				setPrefs((prev) => (sameColumnPrefs(prev, reconciled) ? prev : reconciled));
+				return;
+			}
+			saveColumnPrefs(key, reconciled);
+			setPrefs(reconciled);
+		},
+		[key],
+	);
+
+	const toggleColumn = useCallback(
+		(columnName: string) => {
+			const current = loadColumnPrefs(key);
+			const reconciled = reconcileColumnPrefs(schemaColsRef.current, current);
+			const hiddenSet = new Set(reconciled.hidden);
+			if (hiddenSet.has(columnName)) {
+				hiddenSet.delete(columnName);
+			} else {
+				hiddenSet.add(columnName);
+			}
+			update({ ...reconciled, hidden: [...hiddenSet] });
+		},
+		[key, update],
+	);
+
+	const moveColumn = useCallback(
+		(columnName: string, direction: -1 | 1, scopeCols?: string[]) => {
+			const current = loadColumnPrefs(key);
+			const reconciled = reconcileColumnPrefs(schemaColsRef.current, current);
+			const list = scopeCols ?? reconciled.order;
+			const index = list.indexOf(columnName);
+			const targetIndex = index + direction;
+			if (index === -1 || targetIndex < 0 || targetIndex >= list.length) return;
+			const targetCol = list[targetIndex];
+			const order = reorderColumns(
+				reconciled.order,
+				columnName,
+				targetCol,
+				direction === -1 ? "before" : "after",
+			);
+			update({ ...reconciled, order });
+		},
+		[key, update],
+	);
+
+	const reorderColumn = useCallback(
+		(sourceCol: string, targetCol: string, position?: "before" | "after") => {
+			const current = loadColumnPrefs(key);
+			const reconciled = reconcileColumnPrefs(schemaColsRef.current, current);
+			const order = reorderColumns(reconciled.order, sourceCol, targetCol, position);
+			update({ ...reconciled, order });
+		},
+		[key, update],
+	);
+
+	// Show all makes every database column visible while preserving column order
+	const showAllColumns = useCallback(() => {
+		const current = loadColumnPrefs(key);
+		const reconciled = reconcileColumnPrefs(schemaColsRef.current, current);
+		update({ ...reconciled, hidden: [] });
+	}, [key, update]);
+
+	// Reset restores original schema order and default visibility
+	const resetColumns = useCallback(() => {
+		clearColumnPrefs(key);
+		setPrefs({ order: [], hidden: [] });
+	}, [key]);
+
+	// Full reconciled order (visible + hidden in place) — what the menu renders.
+	const orderedColumns = useMemo(
+		() => reconcileColumnPrefs(schemaCols, prefs).order,
+		[schemaCols, prefs],
+	);
+
+	// Applied view: visible columns in display order — what the table renders.
+	const visibleColumns = useMemo(
+		() => applyColumnPrefs(schemaCols, prefs),
+		[schemaCols, prefs],
+	);
+
+	return {
+		orderedColumns,
+		visibleColumns,
+		toggleColumn,
+		moveColumn,
+		reorderColumn,
+		showAllColumns,
+		resetColumns,
+	};
+};

--- a/packages/web/src/features/tables/hooks/use-table-model.ts
+++ b/packages/web/src/features/tables/hooks/use-table-model.ts
@@ -11,6 +11,7 @@ import type { TableRecord } from "@/types/table.type";
 import { CONSTANTS } from "@/utils/constants";
 import { TableCell } from "../components/table-cell";
 import { TableSelector } from "../components/table-selector";
+import { useColumnPreferences } from "./use-column-preferences";
 
 export const useTableModel = ({
 	tableName,
@@ -35,12 +36,22 @@ export const useTableModel = ({
 		columnId: string;
 	} | null>(null);
 
+	const { visibleColumns } = useColumnPreferences({ tableName, tableCols });
+
+	const visibleCols = useMemo(() => {
+		if (!tableCols) return undefined;
+		const byName = new Map(tableCols.map((col) => [col.columnName, col]));
+		return visibleColumns
+			.map((name) => byName.get(name))
+			.filter((col): col is ColumnInfoSchemaType => !!col);
+	}, [tableCols, visibleColumns]);
+
 	const selectorColumn = useMemo(() => TableSelector(), []);
 
 	const columns = useMemo<ColumnDef<TableRecord, unknown>[]>(
 		() => [
 			selectorColumn,
-			...(tableCols?.map((col) => ({
+			...(visibleCols?.map((col) => ({
 				accessorKey: col.columnName,
 				header: col.columnName,
 				meta: {
@@ -57,7 +68,7 @@ export const useTableModel = ({
 				maxSize: 500,
 			})) || []),
 		],
-		[tableCols, selectorColumn],
+		[visibleCols, selectorColumn],
 	);
 
 	useEffect(() => {

--- a/packages/web/src/features/tables/stores/column-preferences.store.test.ts
+++ b/packages/web/src/features/tables/stores/column-preferences.store.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	applyColumnPrefs,
+	clearColumnPrefs,
+	loadColumnPrefs,
+	makeStorageKey,
+	reconcileColumnPrefs,
+	reorderColumns,
+	saveColumnPrefs,
+} from "./column-preferences.store";
+
+const parts = { dbType: "pg", database: "dbstudio", tableName: "users" };
+
+afterEach(() => {
+	clearColumnPrefs(parts);
+});
+
+describe("load/save", () => {
+	it("round-trips preferences through localStorage", () => {
+		expect(loadColumnPrefs(parts)).toEqual({ order: [], hidden: [] });
+		saveColumnPrefs(parts, { order: ["b", "a"], hidden: ["b"] });
+		expect(loadColumnPrefs(parts)).toEqual({ order: ["b", "a"], hidden: ["b"] });
+	});
+
+	it("keeps preferences isolated between tables and databases", () => {
+		saveColumnPrefs(parts, { order: ["a"], hidden: [] });
+		const otherTable = { ...parts, tableName: "orders" };
+		expect(loadColumnPrefs(otherTable)).toEqual({ order: [], hidden: [] });
+		saveColumnPrefs(otherTable, { order: [], hidden: ["x"] });
+		expect(loadColumnPrefs(parts)).toEqual({ order: ["a"], hidden: [] });
+		const otherDb = { ...parts, database: "otherdb" };
+		expect(loadColumnPrefs(otherDb)).toEqual({ order: [], hidden: [] });
+	});
+
+	it("sanitizes corrupt or partial payloads", () => {
+		window.localStorage.setItem(makeStorageKey(parts), "not json at all");
+		expect(loadColumnPrefs(parts)).toEqual({ order: [], hidden: [] });
+		window.localStorage.setItem(
+			makeStorageKey(parts),
+			JSON.stringify({ order: ["a", 42, null], hidden: "oops", extra: true }),
+		);
+		expect(loadColumnPrefs(parts)).toEqual({ order: ["a"], hidden: [] });
+	});
+});
+
+describe("reconcileColumnPrefs", () => {
+	it("passes through when prefs are empty", () => {
+		expect(reconcileColumnPrefs(["a", "b"], { order: [], hidden: [] })).toEqual({
+			order: ["a", "b"],
+			hidden: [],
+		});
+	});
+
+	it("keeps saved order for known columns and appends new ones", () => {
+		expect(reconcileColumnPrefs(["a", "b", "c"], { order: ["c", "a"], hidden: [] })).toEqual({
+			order: ["c", "a", "b"],
+			hidden: [],
+		});
+	});
+
+	it("discards removed columns from order and hidden", () => {
+		expect(
+			reconcileColumnPrefs(["a"], {
+				order: ["a", "gone"],
+				hidden: ["gone", "a"],
+			}),
+		).toEqual({ order: ["a"], hidden: ["a"] });
+	});
+
+	it("drops duplicate entries from saved order", () => {
+		expect(reconcileColumnPrefs(["a", "b"], { order: ["a", "a", "b"], hidden: [] })).toEqual({
+			order: ["a", "b"],
+			hidden: [],
+		});
+	});
+
+	it("ignores hidden entries that are not schema columns", () => {
+		expect(reconcileColumnPrefs(["a", "b"], { order: [], hidden: ["a", "ghost"] })).toEqual({
+			order: ["a", "b"],
+			hidden: ["a"],
+		});
+	});
+});
+
+describe("applyColumnPrefs", () => {
+	it("returns schema order when nothing is saved", () => {
+		expect(applyColumnPrefs(["a", "b", "c"], { order: [], hidden: [] })).toEqual([
+			"a",
+			"b",
+			"c",
+		]);
+	});
+
+	it("applies saved order and drops hidden columns", () => {
+		expect(
+			applyColumnPrefs(["a", "b", "c"], {
+				order: ["c", "b", "a"],
+				hidden: ["b"],
+			}),
+		).toEqual(["c", "a"]);
+	});
+
+	it("appends newly discovered columns after the saved order", () => {
+		expect(applyColumnPrefs(["a", "b", "new"], { order: ["b", "a"], hidden: [] })).toEqual([
+			"b",
+			"a",
+			"new",
+		]);
+	});
+});
+
+describe("reorderColumns", () => {
+	it("moves a column downwards after the target", () => {
+		expect(reorderColumns(["a", "b", "c", "d"], "a", "c")).toEqual(["b", "c", "a", "d"]);
+	});
+
+	it("moves a column upwards before the target", () => {
+		expect(reorderColumns(["a", "b", "c", "d"], "d", "b")).toEqual(["a", "d", "b", "c"]);
+	});
+
+	it("respects explicit before/after position", () => {
+		expect(reorderColumns(["a", "b", "c"], "a", "b", "before")).toEqual(["a", "b", "c"]);
+		expect(reorderColumns(["a", "b", "c"], "c", "b", "after")).toEqual(["a", "b", "c"]);
+	});
+
+	it("returns unchanged order if source equals target or column missing", () => {
+		expect(reorderColumns(["a", "b"], "a", "a")).toEqual(["a", "b"]);
+		expect(reorderColumns(["a", "b"], "x", "a")).toEqual(["a", "b"]);
+		expect(reorderColumns(["a", "b"], "a", "x")).toEqual(["a", "b"]);
+	});
+});

--- a/packages/web/src/features/tables/stores/column-preferences.store.test.ts
+++ b/packages/web/src/features/tables/stores/column-preferences.store.test.ts
@@ -2,17 +2,21 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	applyColumnPrefs,
 	clearColumnPrefs,
+	clearMemoryFallback,
 	loadColumnPrefs,
 	makeStorageKey,
 	reconcileColumnPrefs,
 	reorderColumns,
+	sameColumnPrefKey,
 	saveColumnPrefs,
+	subscribeColumnPrefsChanged,
 } from "./column-preferences.store";
 
 const parts = { dbType: "pg", database: "dbstudio", tableName: "users" };
 
 afterEach(() => {
 	clearColumnPrefs(parts);
+	clearMemoryFallback();
 });
 
 describe("load/save", () => {
@@ -20,6 +24,12 @@ describe("load/save", () => {
 		expect(loadColumnPrefs(parts)).toEqual({ order: [], hidden: [] });
 		saveColumnPrefs(parts, { order: ["b", "a"], hidden: ["b"] });
 		expect(loadColumnPrefs(parts)).toEqual({ order: ["b", "a"], hidden: ["b"] });
+	});
+
+	it("produces distinct storage keys when database or table names contain colons", () => {
+		const keyA = makeStorageKey({ dbType: "pg", database: "a:b", tableName: "c" });
+		const keyB = makeStorageKey({ dbType: "pg", database: "a", tableName: "b:c" });
+		expect(keyA).not.toBe(keyB);
 	});
 
 	it("keeps preferences isolated between tables and databases", () => {
@@ -40,6 +50,50 @@ describe("load/save", () => {
 			JSON.stringify({ order: ["a", 42, null], hidden: "oops", extra: true }),
 		);
 		expect(loadColumnPrefs(parts)).toEqual({ order: ["a"], hidden: [] });
+	});
+
+	it("synchronizes preferences via in-memory fallback when storage setItem throws", () => {
+		const throwingStorage = {
+			getItem: () => null,
+			setItem: () => {
+				throw new Error("QuotaExceededError");
+			},
+			removeItem: () => {},
+		};
+
+		saveColumnPrefs(parts, { order: ["col2", "col1"], hidden: ["col2"] }, throwingStorage);
+
+		expect(loadColumnPrefs(parts, throwingStorage)).toEqual({
+			order: ["col2", "col1"],
+			hidden: ["col2"],
+		});
+	});
+
+	it("notifies listeners and clears in-memory fallback when removeItem throws", () => {
+		let notified = false;
+		const unsubscribe = subscribeColumnPrefsChanged((changed) => {
+			if (sameColumnPrefKey(changed, parts)) notified = true;
+		});
+
+		const failingStorage = {
+			getItem: () => null,
+			setItem: () => {
+				throw new Error("fail");
+			},
+			removeItem: () => {
+				throw new Error("fail");
+			},
+		};
+
+		saveColumnPrefs(parts, { order: ["a"], hidden: [] }, failingStorage);
+		expect(loadColumnPrefs(parts, failingStorage)).toEqual({ order: ["a"], hidden: [] });
+
+		notified = false;
+		clearColumnPrefs(parts, failingStorage);
+		expect(notified).toBe(true);
+		expect(loadColumnPrefs(parts, failingStorage)).toEqual({ order: [], hidden: [] });
+
+		unsubscribe();
 	});
 });
 

--- a/packages/web/src/features/tables/stores/column-preferences.store.ts
+++ b/packages/web/src/features/tables/stores/column-preferences.store.ts
@@ -1,0 +1,154 @@
+export type ColumnPrefs = {
+	order: string[];
+	hidden: string[];
+};
+
+export type ColumnPrefKeyParts = {
+	dbType: string;
+	database: string;
+	tableName: string;
+};
+
+const STORAGE_PREFIX = "db-studio:columns:";
+
+// Tiny pub/sub so every useColumnPreferences instance (table model, menu, ...)
+// re-reads preferences after any write, staying in sync without prop drilling.
+type PrefsListener = (parts: ColumnPrefKeyParts) => void;
+const listeners = new Set<PrefsListener>();
+
+const notifyPrefsChanged = (parts: ColumnPrefKeyParts): void => {
+	for (const listener of listeners) listener(parts);
+};
+
+export const subscribeColumnPrefsChanged = (listener: PrefsListener): (() => void) => {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+};
+
+export const sameColumnPrefKey = (a: ColumnPrefKeyParts, b: ColumnPrefKeyParts): boolean =>
+	a.dbType === b.dbType && a.database === b.database && a.tableName === b.tableName;
+
+/** Deep equality for prefs — used to skip no-op writes and state updates. */
+export const sameColumnPrefs = (a: ColumnPrefs, b: ColumnPrefs): boolean =>
+	a.order.length === b.order.length &&
+	a.hidden.length === b.hidden.length &&
+	a.order.every((name, i) => name === b.order[i]) &&
+	a.hidden.every((name, i) => name === b.hidden[i]);
+
+export const makeStorageKey = ({ dbType, database, tableName }: ColumnPrefKeyParts): string =>
+	`${STORAGE_PREFIX}${dbType}:${database}:${tableName}`;
+
+const sanitize = (value: unknown): ColumnPrefs => {
+	const raw = (value ?? {}) as Partial<ColumnPrefs>;
+	const order = Array.isArray(raw.order) ? raw.order.filter((c) => typeof c === "string") : [];
+	const hidden = Array.isArray(raw.hidden)
+		? raw.hidden.filter((c) => typeof c === "string")
+		: [];
+	return { order, hidden };
+};
+
+export const loadColumnPrefs = (
+	parts: ColumnPrefKeyParts,
+	storage: Pick<Storage, "getItem" | "setItem" | "removeItem"> = window.localStorage,
+): ColumnPrefs => {
+	try {
+		const raw = storage.getItem(makeStorageKey(parts));
+		return raw ? sanitize(JSON.parse(raw)) : { order: [], hidden: [] };
+	} catch {
+		return { order: [], hidden: [] };
+	}
+};
+
+export const saveColumnPrefs = (
+	parts: ColumnPrefKeyParts,
+	prefs: ColumnPrefs,
+	storage: Pick<Storage, "getItem" | "setItem" | "removeItem"> = window.localStorage,
+): void => {
+	try {
+		storage.setItem(makeStorageKey(parts), JSON.stringify(prefs));
+		notifyPrefsChanged(parts);
+	} catch {
+		// storage full or unavailable; preferences become session-only
+	}
+};
+
+export const clearColumnPrefs = (
+	parts: ColumnPrefKeyParts,
+	storage: Pick<Storage, "getItem" | "setItem" | "removeItem"> = window.localStorage,
+): void => {
+	try {
+		storage.removeItem(makeStorageKey(parts));
+		notifyPrefsChanged(parts);
+	} catch {
+		// ignore
+	}
+};
+
+/**
+ * Reconcile saved prefs against the live schema:
+ * - dropped columns that no longer exist
+ * - appended new columns (in schema order) to the end of the saved order
+ * - dropped hidden entries that no longer exist
+ * The result always contains every schema column exactly once, so the table
+ * never loses a column because of stale preferences.
+ */
+export const reconcileColumnPrefs = (
+	schemaCols: string[],
+	prefs: ColumnPrefs,
+): ColumnPrefs => {
+	const schemaSet = new Set(schemaCols);
+	const seen = new Set<string>();
+	const order: string[] = [];
+	for (const name of prefs.order) {
+		if (schemaSet.has(name) && !seen.has(name)) {
+			order.push(name);
+			seen.add(name);
+		}
+	}
+	for (const name of schemaCols) {
+		if (!seen.has(name)) {
+			order.push(name);
+			seen.add(name);
+		}
+	}
+	const hidden = prefs.hidden.filter(
+		(name) => schemaSet.has(name) && typeof name === "string",
+	);
+	return { order, hidden };
+};
+
+/** Applied view: schema columns ordered by prefs and filtered by hidden. */
+export const applyColumnPrefs = (schemaCols: string[], prefs: ColumnPrefs): string[] => {
+	const { order, hidden } = reconcileColumnPrefs(schemaCols, prefs);
+	const hiddenSet = new Set(hidden);
+	const ordered = order.filter((name) => !hiddenSet.has(name));
+	return [...ordered].sort((a, b) => order.indexOf(a) - order.indexOf(b));
+};
+
+/**
+ * Move a column relative to another target column in the order list.
+ * Safe against index mismatches when lists are filtered by search.
+ */
+export const reorderColumns = (
+	order: string[],
+	sourceCol: string,
+	targetCol: string,
+	position?: "before" | "after",
+): string[] => {
+	if (sourceCol === targetCol) return order;
+	const fromIndex = order.indexOf(sourceCol);
+	const targetIndex = order.indexOf(targetCol);
+	if (fromIndex === -1 || targetIndex === -1) return order;
+
+	const next = [...order];
+	next.splice(fromIndex, 1);
+	const newTargetIndex = next.indexOf(targetCol);
+	const insertIndex =
+		(position ?? (fromIndex < targetIndex ? "after" : "before")) === "after"
+			? newTargetIndex + 1
+			: newTargetIndex;
+	next.splice(insertIndex, 0, sourceCol);
+	return next;
+};

--- a/packages/web/src/features/tables/stores/column-preferences.store.ts
+++ b/packages/web/src/features/tables/stores/column-preferences.store.ts
@@ -38,7 +38,7 @@ export const sameColumnPrefs = (a: ColumnPrefs, b: ColumnPrefs): boolean =>
 	a.hidden.every((name, i) => name === b.hidden[i]);
 
 export const makeStorageKey = ({ dbType, database, tableName }: ColumnPrefKeyParts): string =>
-	`${STORAGE_PREFIX}${dbType}:${database}:${tableName}`;
+	`${STORAGE_PREFIX}${JSON.stringify([dbType, database, tableName])}`;
 
 const sanitize = (value: unknown): ColumnPrefs => {
 	const raw = (value ?? {}) as Partial<ColumnPrefs>;
@@ -49,16 +49,29 @@ const sanitize = (value: unknown): ColumnPrefs => {
 	return { order, hidden };
 };
 
+const memoryFallback = new Map<string, ColumnPrefs>();
+
+export const clearMemoryFallback = (): void => {
+	memoryFallback.clear();
+};
+
 export const loadColumnPrefs = (
 	parts: ColumnPrefKeyParts,
 	storage: Pick<Storage, "getItem" | "setItem" | "removeItem"> = window.localStorage,
 ): ColumnPrefs => {
+	const key = makeStorageKey(parts);
 	try {
-		const raw = storage.getItem(makeStorageKey(parts));
-		return raw ? sanitize(JSON.parse(raw)) : { order: [], hidden: [] };
+		const raw = storage.getItem(key);
+		if (raw) {
+			return sanitize(JSON.parse(raw));
+		}
 	} catch {
-		return { order: [], hidden: [] };
+		// storage unavailable or getItem failed; fall back to in-memory store
 	}
+	const fallback = memoryFallback.get(key);
+	return fallback
+		? { order: [...fallback.order], hidden: [...fallback.hidden] }
+		: { order: [], hidden: [] };
 };
 
 export const saveColumnPrefs = (
@@ -66,24 +79,30 @@ export const saveColumnPrefs = (
 	prefs: ColumnPrefs,
 	storage: Pick<Storage, "getItem" | "setItem" | "removeItem"> = window.localStorage,
 ): void => {
+	const key = makeStorageKey(parts);
+	const sanitized = sanitize(prefs);
 	try {
-		storage.setItem(makeStorageKey(parts), JSON.stringify(prefs));
-		notifyPrefsChanged(parts);
+		storage.setItem(key, JSON.stringify(sanitized));
+		memoryFallback.delete(key);
 	} catch {
 		// storage full or unavailable; preferences become session-only
+		memoryFallback.set(key, sanitized);
 	}
+	notifyPrefsChanged(parts);
 };
 
 export const clearColumnPrefs = (
 	parts: ColumnPrefKeyParts,
 	storage: Pick<Storage, "getItem" | "setItem" | "removeItem"> = window.localStorage,
 ): void => {
+	const key = makeStorageKey(parts);
+	memoryFallback.delete(key);
 	try {
-		storage.removeItem(makeStorageKey(parts));
-		notifyPrefsChanged(parts);
+		storage.removeItem(key);
 	} catch {
 		// ignore
 	}
+	notifyPrefsChanged(parts);
 };
 
 /**


### PR DESCRIPTION
## What does this PR do?

Closes #271

This PR adds a **"Manage columns"** menu to the table header. It lets each user choose which columns to show or hide, and in what order — per table, per database.

## What can the user do with it?

- **Show/hide columns** using checkboxes. The header shows a live count like "2/3 shown".
- **Reorder columns** by dragging them, or with the keyboard (ArrowUp / ArrowDown) for accessibility.
- **Search** the column list. Search only filters the menu — it never changes the table itself.
- **Show all** to quickly re-show every hidden column.
- **Reset** to go back to the default order and visibility.

## How does it work?

- Choices are **saved in localStorage**, scoped to the exact table (dbType + database + table), so each table remembers its own setup after a page reload.
- When the database schema changes, saved preferences are **reconciled automatically**: new columns appear (no data loss), removed columns are cleaned out, and the table never breaks because of stale preferences.
- Utility columns (like the select checkbox and row actions) are **not part of the menu** — only real database columns are manageable.

## Files changed

| File | Purpose |
| --- | --- |
| `column-preferences.store.ts` | Saves/loads preferences, syncs them between components, reconciles with the schema |
| `use-column-preferences.ts` | Hook that applies preferences and exposes toggle/reorder/reset actions |
| `column-preferences-menu.tsx` | The popover menu UI (search, checkboxes, drag & keyboard reorder) |
| `use-table-model.ts` + `table-header.tsx` | Apply visibility/order to the table and add the menu button to the header |

## How was it tested?

- ✅ `bun run typecheck` — passes
- ✅ `bunx biome check` — passes
- ✅ **17/17 vitest tests pass**:
  - 11 store tests: saving, loading, sanitizing bad data, schema reconciliation, cross-component sync
  - 6 menu tests: column listing (no utility columns), shown count, search not touching the table, toggle persistence, case-insensitive search, restoring saved state on reopen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added table column preferences for showing, hiding, searching, and reordering columns.
  * Preferences are saved per table and restored when revisiting.
  * Added “Show all” and “Reset” actions.
  * Added keyboard and drag-and-drop column reordering.
* **Tests**
  * Added coverage for column visibility, search, persistence, resetting, and reordering behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->