### PR TITLE
feat(tables): add PostgreSQL Live mode with automatic row updates

### DIFF
--- a/packages/shared/src/types/database-capabilities.types.ts
+++ b/packages/shared/src/types/database-capabilities.types.ts
@@ -1,0 +1,24 @@
+import type { DatabaseTypeSchema } from "./database.types.js";
+
+export type DatabaseCapability = "liveMode";
+
+export interface DatabaseCapabilities {
+	liveMode: boolean;
+}
+
+export const DATABASE_CAPABILITIES: Record<DatabaseTypeSchema, DatabaseCapabilities> = {
+	pg: { liveMode: true },
+	mysql: { liveMode: false },
+	mssql: { liveMode: false },
+	sqlite: { liveMode: false },
+	mongodb: { liveMode: false },
+	redis: { liveMode: false },
+};
+
+export function hasDatabaseCapability(
+	dbType: DatabaseTypeSchema | null | undefined,
+	capability: DatabaseCapability,
+): boolean {
+	if (!dbType) return false;
+	return DATABASE_CAPABILITIES[dbType]?.[capability] ?? false;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -10,6 +10,7 @@ export * from "./column.type.js";
 export * from "./column-info.types.js";
 export * from "./create-table.types.js"; // done
 export * from "./database.types.js"; // done
+export * from "./database-capabilities.types.js";
 export * from "./database-list.types.js"; // done
 export * from "./database-schema.type.js"; // done
 export * from "./delete-column.types.js"; // done

--- a/packages/web/src/features/tables/components/header/live-mode-toggle.test.tsx
+++ b/packages/web/src/features/tables/components/header/live-mode-toggle.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useLiveModeStore } from "../../stores/live-mode.store";
+import { LiveModeToggle } from "./live-mode-toggle";
+
+describe("LiveModeToggle", () => {
+	beforeEach(() => {
+		useLiveModeStore.getState().reset();
+	});
+
+	it("renders Live button with off indicator by default", () => {
+		render(<LiveModeToggle tableName="users" />);
+
+		const button = screen.getByRole("button", { name: "Toggle Live mode" });
+		expect(button).toBeInTheDocument();
+		expect(button).toHaveAttribute("aria-pressed", "false");
+		expect(screen.getByText("Live")).toBeInTheDocument();
+
+		const dot = screen.getByTestId("live-status-dot");
+		expect(dot).toHaveClass("bg-muted-foreground/40");
+		expect(screen.queryByTestId("live-pulse-indicator")).not.toBeInTheDocument();
+	});
+
+	it("toggles Live mode on click", () => {
+		render(<LiveModeToggle tableName="users" />);
+		const button = screen.getByRole("button", { name: "Toggle Live mode" });
+
+		fireEvent.click(button);
+		expect(useLiveModeStore.getState().isLive).toBe(true);
+		expect(button).toHaveAttribute("aria-pressed", "true");
+
+		const dot = screen.getByTestId("live-status-dot");
+		expect(dot).toHaveClass("bg-emerald-500");
+
+		fireEvent.click(button);
+		expect(useLiveModeStore.getState().isLive).toBe(false);
+		expect(button).toHaveAttribute("aria-pressed", "false");
+	});
+
+	it("displays pulsing indicator when isPulsing is true and healthy", () => {
+		useLiveModeStore.getState().setLive(true, "users");
+		useLiveModeStore.setState({ isPulsing: true });
+		render(<LiveModeToggle tableName="users" />);
+
+		expect(screen.getByTestId("live-pulse-indicator")).toBeInTheDocument();
+		expect(screen.getByTestId("live-status-dot")).toHaveClass("bg-emerald-500");
+	});
+
+	it("displays paused badge and amber dot when paused during edit", () => {
+		useLiveModeStore.getState().setLive(true, "users");
+		useLiveModeStore.getState().pauseLive();
+		render(<LiveModeToggle tableName="users" />);
+
+		expect(screen.getByText("(Paused)")).toBeInTheDocument();
+		const dot = screen.getByTestId("live-status-dot");
+		expect(dot).toHaveClass("bg-amber-400");
+	});
+
+	it("displays disconnected state when disconnected", () => {
+		useLiveModeStore.getState().setLive(true, "users");
+		useLiveModeStore.getState().setStatus("disconnected");
+		render(<LiveModeToggle tableName="users" />);
+
+		const dot = screen.getByTestId("live-status-dot");
+		expect(dot).toHaveClass("bg-amber-500");
+	});
+});

--- a/packages/web/src/features/tables/components/header/live-mode-toggle.tsx
+++ b/packages/web/src/features/tables/components/header/live-mode-toggle.tsx
@@ -1,0 +1,70 @@
+import { Button } from "@db-studio/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@db-studio/ui/tooltip";
+import { cn } from "@db-studio/ui/utils";
+import { useCallback } from "react";
+import { useLiveModeStore } from "../../stores/live-mode.store";
+
+interface LiveModeToggleProps {
+	tableName: string;
+}
+
+export const LiveModeToggle = ({ tableName }: LiveModeToggleProps) => {
+	const isLive = useLiveModeStore((state) => state.isLive);
+	const status = useLiveModeStore((state) => state.status);
+	const isPulsing = useLiveModeStore((state) => state.isPulsing);
+	const setLive = useLiveModeStore((state) => state.setLive);
+
+	const handleToggle = useCallback(() => {
+		setLive(!isLive, tableName);
+	}, [isLive, tableName, setLive]);
+
+	let tooltipText = "Live mode: Automatic 1s PostgreSQL updates (Off)";
+	if (status === "paused") {
+		tooltipText = "Live mode paused while editing. Click to resume.";
+	} else if (isLive && status === "healthy") {
+		tooltipText = "Live mode: Active (healthy, 1s polling)";
+	} else if (isLive && status === "disconnected") {
+		tooltipText = "Live mode: Disconnected. Attempting to reconnect...";
+	}
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Button
+					type="button"
+					variant="ghost"
+					onClick={handleToggle}
+					aria-label="Toggle Live mode"
+					aria-pressed={isLive}
+					className={cn(
+						"h-8! px-2.5 border-l-0 border-y-0 border-r border-border rounded-none text-xs font-medium gap-1.5 flex items-center transition-colors text-muted-foreground hover:text-foreground hover:bg-muted/60",
+						isLive && "text-foreground bg-accent/20",
+					)}
+				>
+					<span className="relative flex size-2 items-center justify-center">
+						{isLive && status === "healthy" && isPulsing && (
+							<span
+								data-testid="live-pulse-indicator"
+								className="absolute inline-flex size-3.5 rounded-full bg-emerald-400 opacity-75 animate-ping"
+							/>
+						)}
+						<span
+							data-testid="live-status-dot"
+							className={cn("relative inline-flex size-2 rounded-full transition-colors", {
+								"bg-emerald-500": isLive && status === "healthy",
+								"bg-amber-500": isLive && status === "disconnected",
+								"bg-amber-400": !isLive && status === "paused",
+								"bg-muted-foreground/40": !isLive && status !== "paused",
+							})}
+						/>
+					</span>
+					<span>Live</span>
+					{status === "paused" && (
+						<span className="text-[10px] text-amber-500 font-normal">(Paused)</span>
+					)}
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom">{tooltipText}</TooltipContent>
+		</Tooltip>
+	);
+};

--- a/packages/web/src/features/tables/components/header/table-header.tsx
+++ b/packages/web/src/features/tables/components/header/table-header.tsx
@@ -1,10 +1,12 @@
 import type { OnChangeFn, Row, RowSelectionState } from "@tanstack/react-table";
+import { useDatabaseCapability } from "@/hooks/use-database-capabilities";
 import { useIsSchemaless } from "@/hooks/use-is-schemaless";
 import type { TableRecord } from "@/types/table.type";
 import { AddRecordMenu } from "./add-record-menu";
 import { ClearBtn } from "./clear-btn";
 import { DeleteBtn } from "./delete-btn";
 import { FilterPopup } from "./filter-popup";
+import { LiveModeToggle } from "./live-mode-toggle";
 import { RefetchBtn } from "./refetch-btn";
 import { SaveBtn } from "./save-btn";
 
@@ -18,11 +20,13 @@ export const TableHeader = ({
 	tableName: string;
 }) => {
 	const isSchemaless = useIsSchemaless();
+	const canLiveMode = useDatabaseCapability("liveMode");
 
 	return (
 		<header className="max-h-8 overflow-hidden border-b border-border w-full flex items-center justify-between bg-background sticky top-0 left-0 right-0 z-0">
 			<div className="flex items-center ">
 				<RefetchBtn tableName={tableName} />
+				{canLiveMode && <LiveModeToggle tableName={tableName} />}
 				{!isSchemaless && <FilterPopup tableName={tableName} />}
 				<AddRecordMenu />
 				<SaveBtn setRowSelection={setRowSelection} />

--- a/packages/web/src/features/tables/components/table-body-row.tsx
+++ b/packages/web/src/features/tables/components/table-body-row.tsx
@@ -1,6 +1,8 @@
+import { cn } from "@db-studio/ui/utils";
 import { flexRender, type Row } from "@tanstack/react-table";
 import type { VirtualItem, Virtualizer } from "@tanstack/react-virtual";
 import type { TableRecord } from "@/types/table.type";
+import { useLiveModeStore } from "../stores/live-mode.store";
 import { CellCopyButton } from "./cell-copy-button";
 
 interface TableBodyRowProps {
@@ -22,12 +24,18 @@ export const TableBodyRow = ({
 }: TableBodyRowProps) => {
 	const visibleCells = row.getVisibleCells();
 	const virtualColumns = columnVirtualizer.getVirtualItems();
+	const isRowHighlighted = useLiveModeStore((state) => state.highlightedRowIds.has(row.id));
+
 	return (
 		<tr
 			data-index={virtualRow.index} //needed for dynamic row height measurement
 			ref={(node) => rowVirtualizer.measureElement(node)} //measure dynamic row height
 			key={row.id}
-			className="flex absolute w-fit border-b items-center justify-between text-sm hover:bg-accent/20 data-[state=open]:bg-accent/40 [&_svg]:size-4"
+			className={cn(
+				"flex absolute w-fit border-b items-center justify-between text-sm hover:bg-accent/20 data-[state=open]:bg-accent/40 [&_svg]:size-4",
+				isRowHighlighted &&
+					"bg-emerald-500/15 dark:bg-emerald-500/20 transition-colors duration-1000 ease-in-out",
+			)}
 			style={{
 				transform: `translateY(${virtualRow.start}px)`, //this should always be a `style` as it changes on scroll
 			}}

--- a/packages/web/src/features/tables/components/table-cell-wrapper.tsx
+++ b/packages/web/src/features/tables/components/table-cell-wrapper.tsx
@@ -2,6 +2,7 @@ import { cn } from "@db-studio/ui/utils";
 import type { Cell, Table } from "@tanstack/react-table";
 import { type ComponentProps, type KeyboardEvent, type MouseEvent, useCallback } from "react";
 import type { TableRecord } from "@/types/table.type";
+import { useLiveModeStore } from "../stores/live-mode.store";
 import { useUpdateCellStore } from "../stores/update-cell.store";
 
 interface TableCellWrapperProps<TData> extends ComponentProps<"div"> {
@@ -137,6 +138,10 @@ export function TableCellWrapper<TData>({
 		},
 		[onKeyDownProp, isFocused, isEditing, meta, rowIndex, columnId],
 	);
+	const isCellHighlighted = useLiveModeStore((state) =>
+		state.highlightedCellKeys.has(`${cell.row.id}:${columnId}`),
+	);
+
 	return (
 		<div
 			role="button"
@@ -154,6 +159,8 @@ export function TableCellWrapper<TData>({
 					"bg-primary/10": isSelected && !isEditing,
 					"cursor-default": !isEditing,
 					"ring-2 ring-primary": hasUpdate,
+					"bg-emerald-500/20 dark:bg-emerald-500/25 transition-colors duration-1000 ease-in-out":
+						isCellHighlighted,
 				},
 				className,
 			)}

--- a/packages/web/src/features/tables/components/table-row-cell-highlight.test.tsx
+++ b/packages/web/src/features/tables/components/table-row-cell-highlight.test.tsx
@@ -1,0 +1,67 @@
+import type { Cell, Table } from "@tanstack/react-table";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { TableRecord } from "@/types/table.type";
+import { useLiveModeStore } from "../stores/live-mode.store";
+import { TableCellWrapper } from "./table-cell-wrapper";
+
+describe("Row and Cell Highlight Reactivity in DOM", () => {
+	beforeEach(() => {
+		useLiveModeStore.getState().reset();
+	});
+
+	it("applies highlight class to cell when cell key is in highlightedCellKeys", () => {
+		const mockCell = {
+			row: { id: "row-1", original: { id: "row-1", name: "Alice" } },
+			column: { id: "name" },
+		} as unknown as Cell<TableRecord, unknown>;
+		const mockTable = {
+			options: {
+				meta: {},
+			},
+		} as unknown as Table<TableRecord>;
+
+		const { rerender } = render(
+			<TableCellWrapper
+				cell={mockCell}
+				table={mockTable}
+				rowIndex={0}
+				columnId="name"
+				isEditing={false}
+				isFocused={false}
+				isSelected={false}
+			>
+				<span>Alice</span>
+			</TableCellWrapper>,
+		);
+
+		const wrapper = screen.getByRole("button");
+		expect(wrapper).not.toHaveClass("bg-emerald-500/20");
+
+		act(() => {
+			useLiveModeStore.getState().setHighlights(["row-1"], ["row-1:name"]);
+		});
+		rerender(
+			<TableCellWrapper
+				cell={mockCell}
+				table={mockTable}
+				rowIndex={0}
+				columnId="name"
+				isEditing={false}
+				isFocused={false}
+				isSelected={false}
+			>
+				<span>Alice</span>
+			</TableCellWrapper>,
+		);
+
+		expect(wrapper).toHaveClass("bg-emerald-500/20");
+
+		act(() => {
+			useLiveModeStore.getState().clearHighlights();
+		});
+
+		expect(wrapper).not.toHaveClass("bg-emerald-500/20");
+	});
+});

--- a/packages/web/src/features/tables/components/table-tab-container.tsx
+++ b/packages/web/src/features/tables/components/table-tab-container.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useTableCols } from "@/features/schema";
 import { useDatabaseStore } from "@/stores/database.store";
 import type { TableRecord } from "@/types/table.type";
+import { useLiveTable } from "../hooks/use-live-table";
 import { useTableData } from "../hooks/use-table-data";
 import { useTableModel } from "../hooks/use-table-model";
 import { TableDocumentView } from "./table-document-view";
@@ -12,7 +13,7 @@ import { TableLoadingState } from "./table-loading-state";
 
 export const TableTabContainer = ({ tableName }: { tableName: string }) => {
 	const { dbType } = useDatabaseStore();
-	const { tableData, isLoadingTableData, errorTableData } = useTableData({
+	const { tableData, isLoadingTableData, errorTableData, refetchTableData } = useTableData({
 		tableName,
 	});
 	const { tableCols, isLoadingTableCols, errorTableCols } = useTableCols({
@@ -21,17 +22,28 @@ export const TableTabContainer = ({ tableName }: { tableName: string }) => {
 
 	const tableDataRows = useMemo<TableRecord[]>(() => tableData?.data || [], [tableData?.data]);
 
-	const { table, selectedRows, setRowSelection } = useTableModel({
+	const { table, selectedRows, setRowSelection, isEditingCell } = useTableModel({
 		tableName,
 		tableCols,
 		tableDataRows,
+	});
+
+	useLiveTable({
+		tableName,
+		tableCols,
+		tableDataRows,
+		refetchTableData,
+		isEditingCell,
 	});
 
 	if (isLoadingTableData || isLoadingTableCols) {
 		return <TableLoadingState />;
 	}
 
-	if (errorTableData || errorTableCols) {
+	const hasInitialLoadError =
+		(!tableData && !!errorTableData) || (!tableCols && !!errorTableCols);
+
+	if (hasInitialLoadError) {
 		return (
 			<TableErrorState
 				tableName={tableName}

--- a/packages/web/src/features/tables/hooks/use-live-table.test.ts
+++ b/packages/web/src/features/tables/hooks/use-live-table.test.ts
@@ -1,0 +1,279 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDatabaseStore } from "@/stores/database.store";
+import { useOverlayStore } from "@/stores/overlay.store";
+import type { TableRecord } from "@/types/table.type";
+import { useLiveModeStore } from "../stores/live-mode.store";
+import { useUpdateCellStore } from "../stores/update-cell.store";
+import { useLiveTable } from "./use-live-table";
+
+describe("useLiveTable", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		useDatabaseStore.setState({ dbType: "pg" });
+		useLiveModeStore.getState().reset();
+		useUpdateCellStore.getState().clearUpdates();
+		useOverlayStore.getState().closeAllOverlays();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("does not poll when Live mode is disabled", () => {
+		const refetch = vi.fn().mockResolvedValue({ isError: false });
+		renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: [],
+				refetchTableData: refetch,
+			}),
+		);
+
+		vi.advanceTimersByTime(3000);
+		expect(refetch).not.toHaveBeenCalled();
+	});
+
+	it("polls every 1 second when Live mode is enabled", async () => {
+		const refetch = vi.fn().mockResolvedValue({ isError: false });
+		const { result } = renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: [],
+				refetchTableData: refetch,
+			}),
+		);
+
+		act(() => {
+			result.current.toggleLive();
+		});
+
+		expect(result.current.isLive).toBe(true);
+		expect(refetch).toHaveBeenCalledTimes(1); // Immediate on toggle
+
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+		expect(refetch).toHaveBeenCalledTimes(2);
+
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+		expect(refetch).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not enable or poll if database does not support liveMode", () => {
+		useDatabaseStore.setState({ dbType: "mysql" });
+		const refetch = vi.fn().mockResolvedValue({ isError: false });
+
+		const { result } = renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: [],
+				refetchTableData: refetch,
+			}),
+		);
+
+		expect(result.current.canLiveMode).toBe(false);
+
+		act(() => {
+			result.current.toggleLive();
+		});
+
+		expect(result.current.isLive).toBe(false);
+		vi.advanceTimersByTime(2000);
+		expect(refetch).not.toHaveBeenCalled();
+	});
+
+	it("pauses Live mode when user begins cell editing", () => {
+		const refetch = vi.fn().mockResolvedValue({ isError: false });
+		let isEditingCell = false;
+
+		const { rerender } = renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: [],
+				refetchTableData: refetch,
+				isEditingCell,
+			}),
+		);
+
+		act(() => {
+			useLiveModeStore.getState().setLive(true, "users");
+		});
+		expect(useLiveModeStore.getState().isLive).toBe(true);
+
+		isEditingCell = true;
+		act(() => {
+			rerender();
+		});
+
+		expect(useLiveModeStore.getState().isLive).toBe(false);
+		expect(useLiveModeStore.getState().status).toBe("paused");
+	});
+
+	it("pauses Live mode when pending cell updates exist", () => {
+		const refetch = vi.fn().mockResolvedValue({ isError: false });
+
+		const { rerender } = renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: [],
+				refetchTableData: refetch,
+			}),
+		);
+
+		act(() => {
+			useLiveModeStore.getState().setLive(true, "users");
+		});
+		expect(useLiveModeStore.getState().isLive).toBe(true);
+
+		act(() => {
+			useUpdateCellStore.getState().setUpdate({ id: 1 }, "name", "New Name", "Old Name");
+		});
+		act(() => {
+			rerender();
+		});
+
+		expect(useLiveModeStore.getState().isLive).toBe(false);
+		expect(useLiveModeStore.getState().status).toBe("paused");
+	});
+
+	it("pauses Live mode when a record sheet overlay is opened", () => {
+		const refetch = vi.fn().mockResolvedValue({ isError: false });
+
+		const { rerender } = renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: [],
+				refetchTableData: refetch,
+			}),
+		);
+
+		act(() => {
+			useLiveModeStore.getState().setLive(true, "users");
+		});
+
+		act(() => {
+			useOverlayStore.getState().openOverlay("records.add-record");
+		});
+		act(() => {
+			rerender();
+		});
+
+		expect(useLiveModeStore.getState().isLive).toBe(false);
+		expect(useLiveModeStore.getState().status).toBe("paused");
+	});
+
+	it("pulses and sets highlights when data changes during Live mode", () => {
+		const refetch = vi.fn().mockResolvedValue({ isError: false });
+		let rows: TableRecord[] = [{ id: 1, name: "Alice" }];
+
+		const { rerender } = renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: rows,
+				refetchTableData: refetch,
+			}),
+		);
+
+		act(() => {
+			useLiveModeStore.getState().setLive(true, "users");
+		});
+
+		rows = [
+			{ id: 1, name: "Alice Updated" },
+			{ id: 2, name: "Bob Inserted" },
+		];
+		rerender();
+
+		expect(useLiveModeStore.getState().isPulsing).toBe(true);
+		expect(useLiveModeStore.getState().isRowHighlighted("2")).toBe(true);
+		expect(useLiveModeStore.getState().isCellHighlighted("1", "name")).toBe(true);
+	});
+
+	it("cleans up Live state on unmount", () => {
+		const refetch = vi.fn().mockResolvedValue({ isError: false });
+		const { unmount } = renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: [],
+				refetchTableData: refetch,
+			}),
+		);
+
+		act(() => {
+			useLiveModeStore.getState().setLive(true, "users");
+		});
+
+		unmount();
+		expect(useLiveModeStore.getState().isLive).toBe(false);
+		expect(useLiveModeStore.getState().status).toBe("idle");
+	});
+
+	it("stops polling when tab is hidden and polls immediately when tab becomes visible", async () => {
+		const refetch = vi.fn().mockResolvedValue({ isError: false });
+		const { result } = renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: [],
+				refetchTableData: refetch,
+			}),
+		);
+
+		act(() => {
+			result.current.toggleLive();
+		});
+		expect(refetch).toHaveBeenCalledTimes(1);
+
+		// Hide tab
+		Object.defineProperty(document, "hidden", { value: true, configurable: true });
+
+		await act(async () => {
+			vi.advanceTimersByTime(2000);
+		});
+		// Should not have polled while hidden
+		expect(refetch).toHaveBeenCalledTimes(1);
+
+		// Tab becomes visible again
+		Object.defineProperty(document, "hidden", { value: false, configurable: true });
+		act(() => {
+			document.dispatchEvent(new Event("visibilitychange"));
+		});
+
+		// Should poll immediately upon becoming visible
+		expect(refetch).toHaveBeenCalledTimes(2);
+
+		// And resume 1s interval
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+		expect(refetch).toHaveBeenCalledTimes(3);
+	});
+
+	it("cleans up Live state when database switches", () => {
+		const refetch = vi.fn().mockResolvedValue({ isError: false });
+		const { rerender } = renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: [],
+				refetchTableData: refetch,
+			}),
+		);
+
+		act(() => {
+			useLiveModeStore.getState().setLive(true, "users");
+		});
+		expect(useLiveModeStore.getState().isLive).toBe(true);
+
+		act(() => {
+			useDatabaseStore.setState({ selectedDatabase: "other_db" });
+		});
+		act(() => {
+			rerender();
+		});
+
+		expect(useLiveModeStore.getState().isLive).toBe(false);
+		expect(useLiveModeStore.getState().status).toBe("idle");
+	});
+});

--- a/packages/web/src/features/tables/hooks/use-live-table.test.ts
+++ b/packages/web/src/features/tables/hooks/use-live-table.test.ts
@@ -10,7 +10,7 @@ import { useLiveTable } from "./use-live-table";
 describe("useLiveTable", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
-		useDatabaseStore.setState({ dbType: "pg" });
+		useDatabaseStore.setState({ dbType: "pg", selectedDatabase: "default_db" });
 		useLiveModeStore.getState().reset();
 		useUpdateCellStore.getState().clearUpdates();
 		useOverlayStore.getState().closeAllOverlays();
@@ -274,6 +274,89 @@ describe("useLiveTable", () => {
 		});
 
 		expect(useLiveModeStore.getState().isLive).toBe(false);
+		expect(useLiveModeStore.getState().status).toBe("idle");
+	});
+
+	it("ignores in-flight poll completion after editing pauses Live mode", async () => {
+		let resolvePoll: ((value: unknown) => void) | null = null;
+		const refetch = vi.fn().mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolvePoll = resolve;
+				}),
+		);
+		let isEditingCell = false;
+
+		const { rerender } = renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: [],
+				refetchTableData: refetch,
+				isEditingCell,
+			}),
+		);
+
+		act(() => {
+			useLiveModeStore.getState().setLive(true, "users");
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+		expect(refetch).toHaveBeenCalled();
+
+		isEditingCell = true;
+		act(() => {
+			rerender();
+		});
+		expect(useLiveModeStore.getState().status).toBe("paused");
+		expect(useLiveModeStore.getState().isLive).toBe(false);
+
+		await act(async () => {
+			resolvePoll?.({ isError: false });
+		});
+
+		expect(useLiveModeStore.getState().status).toBe("paused");
+	});
+
+	it("ignores in-flight poll completion after database switch", async () => {
+		let resolvePoll: ((value: unknown) => void) | null = null;
+		const refetch = vi.fn().mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolvePoll = resolve;
+				}),
+		);
+
+		const { rerender } = renderHook(() =>
+			useLiveTable({
+				tableName: "users",
+				tableDataRows: [],
+				refetchTableData: refetch,
+			}),
+		);
+
+		act(() => {
+			useLiveModeStore.getState().setLive(true, "users");
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+		expect(refetch).toHaveBeenCalled();
+
+		act(() => {
+			useDatabaseStore.setState({ selectedDatabase: "other_db" });
+		});
+		act(() => {
+			rerender();
+		});
+		expect(useLiveModeStore.getState().status).toBe("idle");
+
+		await act(async () => {
+			resolvePoll?.({ isError: false });
+		});
+
 		expect(useLiveModeStore.getState().status).toBe("idle");
 	});
 });

--- a/packages/web/src/features/tables/hooks/use-live-table.ts
+++ b/packages/web/src/features/tables/hooks/use-live-table.ts
@@ -1,0 +1,160 @@
+import type { ColumnInfoSchemaType } from "@db-studio/shared/types";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useDatabaseCapability } from "@/hooks/use-database-capabilities";
+import { useDatabaseStore } from "@/stores/database.store";
+import { useOverlayStore } from "@/stores/overlay.store";
+import type { TableRecord } from "@/types/table.type";
+import { useLiveModeStore } from "../stores/live-mode.store";
+import { useUpdateCellStore } from "../stores/update-cell.store";
+import { diffTableRows } from "../utils/table-diff";
+
+const LIVE_POLL_INTERVAL_MS = 1000;
+
+interface UseLiveTableProps {
+	tableName: string;
+	tableCols?: ColumnInfoSchemaType[];
+	tableDataRows: TableRecord[];
+	refetchTableData: () => Promise<unknown>;
+	isEditingCell?: boolean;
+}
+
+export const useLiveTable = ({
+	tableName,
+	tableCols,
+	tableDataRows,
+	refetchTableData,
+	isEditingCell = false,
+}: UseLiveTableProps) => {
+	const canLiveMode = useDatabaseCapability("liveMode");
+
+	const isLive = useLiveModeStore((state) => state.isLive);
+	const status = useLiveModeStore((state) => state.status);
+	const isPulsing = useLiveModeStore((state) => state.isPulsing);
+	const setLive = useLiveModeStore((state) => state.setLive);
+	const pauseLive = useLiveModeStore((state) => state.pauseLive);
+	const setStatus = useLiveModeStore((state) => state.setStatus);
+	const triggerPulse = useLiveModeStore((state) => state.triggerPulse);
+	const setHighlights = useLiveModeStore((state) => state.setHighlights);
+	const isRowHighlighted = useLiveModeStore((state) => state.isRowHighlighted);
+	const isCellHighlighted = useLiveModeStore((state) => state.isCellHighlighted);
+	const reset = useLiveModeStore((state) => state.reset);
+
+	const hasCellUpdates = useUpdateCellStore((state) => state.hasAnyUpdates());
+	const hasOpenRecordOverlay = useOverlayStore((state) =>
+		state.openOverlays.some((id) => id.startsWith("records.")),
+	);
+
+	const isEditing = isEditingCell || hasCellUpdates || hasOpenRecordOverlay;
+
+	const pkCols = useMemo(
+		() => tableCols?.filter((c) => c.isPrimaryKey).map((c) => c.columnName) ?? [],
+		[tableCols],
+	);
+
+	const prevRowsRef = useRef<TableRecord[] | null>(null);
+	const refetchRef = useRef(refetchTableData);
+	refetchRef.current = refetchTableData;
+
+	// Pause Live mode when editing begins
+	useEffect(() => {
+		if (isLive && isEditing) {
+			pauseLive();
+		}
+	}, [isLive, isEditing, pauseLive]);
+
+	// Diff rows and trigger visual highlights when tableDataRows changes during Live mode
+	useEffect(() => {
+		if (isLive && prevRowsRef.current !== null) {
+			const diff = diffTableRows(prevRowsRef.current, tableDataRows, pkCols);
+			if (diff.hasVisibleChanges) {
+				triggerPulse();
+				setHighlights(diff.insertedRowIds, diff.changedCellKeys);
+			}
+		}
+		prevRowsRef.current = tableDataRows;
+	}, [tableDataRows, isLive, pkCols, triggerPulse, setHighlights]);
+
+	// Polling execution helper
+	const executePoll = useCallback(async () => {
+		if (typeof document !== "undefined" && document.hidden) {
+			return;
+		}
+		if (isEditing) {
+			pauseLive();
+			return;
+		}
+
+		try {
+			const res = await refetchRef.current();
+			if (res && typeof res === "object" && "isError" in res && res.isError) {
+				setStatus("disconnected");
+			} else {
+				setStatus("healthy");
+			}
+		} catch {
+			setStatus("disconnected");
+		}
+	}, [isEditing, pauseLive, setStatus]);
+
+	const selectedDatabase = useDatabaseStore((state) => state.selectedDatabase);
+
+	// 1-second polling interval lifecycle
+	useEffect(() => {
+		if (!isLive || !canLiveMode) {
+			return;
+		}
+
+		// Execute immediate poll upon enabling Live mode
+		executePoll();
+
+		const intervalId = setInterval(() => {
+			executePoll();
+		}, LIVE_POLL_INTERVAL_MS);
+
+		return () => {
+			clearInterval(intervalId);
+		};
+	}, [isLive, canLiveMode, executePoll]);
+
+	// Stop polling when tab is hidden, poll immediately when tab becomes visible
+	useEffect(() => {
+		if (!isLive || !canLiveMode) return;
+
+		const handleVisibilityChange = () => {
+			if (!document.hidden && isLive) {
+				executePoll();
+			}
+		};
+
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+		return () => {
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+		};
+	}, [isLive, canLiveMode, executePoll]);
+
+	// Cleanup on table, database, or route switch
+	useEffect(() => {
+		return () => {
+			reset();
+		};
+	}, [tableName, selectedDatabase, reset]);
+
+	const toggleLive = useCallback(() => {
+		if (!canLiveMode) return;
+		if (isLive) {
+			setLive(false);
+		} else {
+			setLive(true, tableName);
+		}
+	}, [canLiveMode, isLive, tableName, setLive]);
+
+	return {
+		canLiveMode,
+		isLive,
+		status,
+		isPulsing,
+		isRowHighlighted,
+		isCellHighlighted,
+		toggleLive,
+	};
+};

--- a/packages/web/src/features/tables/hooks/use-live-table.ts
+++ b/packages/web/src/features/tables/hooks/use-live-table.ts
@@ -38,6 +38,7 @@ export const useLiveTable = ({
 	const isRowHighlighted = useLiveModeStore((state) => state.isRowHighlighted);
 	const isCellHighlighted = useLiveModeStore((state) => state.isCellHighlighted);
 	const reset = useLiveModeStore((state) => state.reset);
+	const selectedDatabase = useDatabaseStore((state) => state.selectedDatabase);
 
 	const hasCellUpdates = useUpdateCellStore((state) => state.hasAnyUpdates());
 	const hasOpenRecordOverlay = useOverlayStore((state) =>
@@ -54,10 +55,16 @@ export const useLiveTable = ({
 	const prevRowsRef = useRef<TableRecord[] | null>(null);
 	const refetchRef = useRef(refetchTableData);
 	refetchRef.current = refetchTableData;
+	const sessionRef = useRef(0);
+	const tableNameRef = useRef(tableName);
+	tableNameRef.current = tableName;
+	const selectedDatabaseRef = useRef(selectedDatabase);
+	selectedDatabaseRef.current = selectedDatabase;
 
 	// Pause Live mode when editing begins
 	useEffect(() => {
 		if (isLive && isEditing) {
+			sessionRef.current += 1;
 			pauseLive();
 		}
 	}, [isLive, isEditing, pauseLive]);
@@ -80,23 +87,46 @@ export const useLiveTable = ({
 			return;
 		}
 		if (isEditing) {
+			sessionRef.current += 1;
 			pauseLive();
 			return;
 		}
 
+		const currentSession = sessionRef.current;
+		const currentTable = tableNameRef.current;
+		const currentDatabase = selectedDatabaseRef.current;
+
 		try {
 			const res = await refetchRef.current();
+			const liveState = useLiveModeStore.getState();
+			if (
+				sessionRef.current !== currentSession ||
+				!liveState.isLive ||
+				tableNameRef.current !== currentTable ||
+				selectedDatabaseRef.current !== currentDatabase
+			) {
+				return;
+			}
+
 			if (res && typeof res === "object" && "isError" in res && res.isError) {
 				setStatus("disconnected");
 			} else {
 				setStatus("healthy");
 			}
 		} catch {
+			const liveState = useLiveModeStore.getState();
+			if (
+				sessionRef.current !== currentSession ||
+				!liveState.isLive ||
+				tableNameRef.current !== currentTable ||
+				selectedDatabaseRef.current !== currentDatabase
+			) {
+				return;
+			}
+
 			setStatus("disconnected");
 		}
 	}, [isEditing, pauseLive, setStatus]);
-
-	const selectedDatabase = useDatabaseStore((state) => state.selectedDatabase);
 
 	// 1-second polling interval lifecycle
 	useEffect(() => {
@@ -134,13 +164,16 @@ export const useLiveTable = ({
 
 	// Cleanup on table, database, or route switch
 	useEffect(() => {
+		sessionRef.current += 1;
 		return () => {
+			sessionRef.current += 1;
 			reset();
 		};
 	}, [tableName, selectedDatabase, reset]);
 
 	const toggleLive = useCallback(() => {
 		if (!canLiveMode) return;
+		sessionRef.current += 1;
 		if (isLive) {
 			setLive(false);
 		} else {

--- a/packages/web/src/features/tables/hooks/use-table-model.ts
+++ b/packages/web/src/features/tables/hooks/use-table-model.ts
@@ -11,15 +11,21 @@ import type { TableRecord } from "@/types/table.type";
 import { CONSTANTS } from "@/utils/constants";
 import { TableCell } from "../components/table-cell";
 import { TableSelector } from "../components/table-selector";
+import { useLiveModeStore } from "../stores/live-mode.store";
+import { getRecordKey } from "../utils/table-diff";
 
 export const useTableModel = ({
 	tableName,
 	tableCols,
 	tableDataRows,
+	isRowHighlighted,
+	isCellHighlighted,
 }: {
 	tableName: string;
 	tableCols?: ColumnInfoSchemaType[];
 	tableDataRows: TableRecord[];
+	isRowHighlighted?: (rowId: string) => boolean;
+	isCellHighlighted?: (rowId: string, columnId: string) => boolean;
 }) => {
 	const [columnName] = useQueryState(CONSTANTS.COLUMN_NAME);
 	const [order] = useQueryState(CONSTANTS.TABLE_STATE_KEYS.ORDER);
@@ -90,6 +96,13 @@ export const useTableModel = ({
 	const handleDataUpdate = useCallback(() => {}, []);
 	const getIsCellSelected = useCallback(() => false, []);
 
+	const pkCols = useMemo(
+		() => tableCols?.filter((col) => col.isPrimaryKey).map((col) => col.columnName) ?? [],
+		[tableCols],
+	);
+
+	const getRowId = useCallback((row: TableRecord) => getRecordKey(row, pkCols), [pkCols]);
+
 	const tableMeta = useMemo(
 		() => ({
 			editScope: tableName,
@@ -101,6 +114,13 @@ export const useTableModel = ({
 			onCellEditingStop: handleCellEditingStop,
 			onDataUpdate: handleDataUpdate,
 			getIsCellSelected,
+			isRowHighlighted:
+				isRowHighlighted ??
+				((rowId: string) => useLiveModeStore.getState().isRowHighlighted(rowId)),
+			isCellHighlighted:
+				isCellHighlighted ??
+				((rowId: string, columnId: string) =>
+					useLiveModeStore.getState().isCellHighlighted(rowId, columnId)),
 		}),
 		[
 			tableName,
@@ -112,6 +132,8 @@ export const useTableModel = ({
 			handleCellEditingStop,
 			handleDataUpdate,
 			getIsCellSelected,
+			isRowHighlighted,
+			isCellHighlighted,
 		],
 	);
 
@@ -124,6 +146,7 @@ export const useTableModel = ({
 			minSize: 100,
 			maxSize: 500,
 		},
+		getRowId,
 		getCoreRowModel: getCoreRowModel(),
 		getSortedRowModel: getSortedRowModel(),
 		state: {
@@ -145,5 +168,6 @@ export const useTableModel = ({
 		table,
 		selectedRows: table.getSelectedRowModel().rows,
 		setRowSelection,
+		isEditingCell: !!editingCell,
 	};
 };

--- a/packages/web/src/features/tables/stores/live-mode.store.test.ts
+++ b/packages/web/src/features/tables/stores/live-mode.store.test.ts
@@ -73,6 +73,17 @@ describe("useLiveModeStore", () => {
 		vi.useRealTimers();
 	});
 
+	it("clears active highlights when setHighlights is called with empty arrays", () => {
+		vi.useFakeTimers();
+		useLiveModeStore.getState().setHighlights(["row-1"], ["row-1:title"]);
+		expect(useLiveModeStore.getState().isRowHighlighted("row-1")).toBe(true);
+
+		useLiveModeStore.getState().setHighlights([], []);
+		expect(useLiveModeStore.getState().isRowHighlighted("row-1")).toBe(false);
+		expect(useLiveModeStore.getState().isCellHighlighted("row-1", "title")).toBe(false);
+		vi.useRealTimers();
+	});
+
 	it("resets all state cleanly", () => {
 		useLiveModeStore.getState().setLive(true, "users");
 		useLiveModeStore.getState().setHighlights(["1"], ["1:name"]);

--- a/packages/web/src/features/tables/stores/live-mode.store.test.ts
+++ b/packages/web/src/features/tables/stores/live-mode.store.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useLiveModeStore } from "./live-mode.store";
+
+describe("useLiveModeStore", () => {
+	beforeEach(() => {
+		useLiveModeStore.getState().reset();
+	});
+
+	it("starts with Live mode disabled and idle", () => {
+		const state = useLiveModeStore.getState();
+		expect(state.isLive).toBe(false);
+		expect(state.status).toBe("idle");
+		expect(state.isPulsing).toBe(false);
+		expect(state.activeTable).toBeNull();
+		expect(state.highlightedRowIds.size).toBe(0);
+		expect(state.highlightedCellKeys.size).toBe(0);
+	});
+
+	it("enables Live mode and marks healthy status", () => {
+		useLiveModeStore.getState().setLive(true, "posts");
+		const state = useLiveModeStore.getState();
+		expect(state.isLive).toBe(true);
+		expect(state.status).toBe("healthy");
+		expect(state.activeTable).toBe("posts");
+	});
+
+	it("disables Live mode and returns to idle", () => {
+		useLiveModeStore.getState().setLive(true, "posts");
+		useLiveModeStore.getState().setLive(false);
+		const state = useLiveModeStore.getState();
+		expect(state.isLive).toBe(false);
+		expect(state.status).toBe("idle");
+	});
+
+	it("pauses Live mode and marks paused status", () => {
+		useLiveModeStore.getState().setLive(true, "posts");
+		useLiveModeStore.getState().pauseLive();
+		const state = useLiveModeStore.getState();
+		expect(state.isLive).toBe(false);
+		expect(state.status).toBe("paused");
+	});
+
+	it("sets disconnected error status", () => {
+		useLiveModeStore.getState().setLive(true, "posts");
+		useLiveModeStore.getState().setStatus("disconnected");
+		expect(useLiveModeStore.getState().status).toBe("disconnected");
+	});
+
+	it("pulses green indicator and auto-clears after timeout", () => {
+		vi.useFakeTimers();
+		useLiveModeStore.getState().setLive(true, "posts");
+		useLiveModeStore.getState().triggerPulse();
+		expect(useLiveModeStore.getState().isPulsing).toBe(true);
+
+		vi.advanceTimersByTime(800);
+		expect(useLiveModeStore.getState().isPulsing).toBe(false);
+		vi.useRealTimers();
+	});
+
+	it("sets row and cell highlights and clears after duration", () => {
+		vi.useFakeTimers();
+		useLiveModeStore.getState().setHighlights(["row-1", "row-2"], ["row-1:title"]);
+
+		expect(useLiveModeStore.getState().isRowHighlighted("row-1")).toBe(true);
+		expect(useLiveModeStore.getState().isRowHighlighted("row-2")).toBe(true);
+		expect(useLiveModeStore.getState().isRowHighlighted("row-3")).toBe(false);
+		expect(useLiveModeStore.getState().isCellHighlighted("row-1", "title")).toBe(true);
+		expect(useLiveModeStore.getState().isCellHighlighted("row-1", "body")).toBe(false);
+
+		vi.advanceTimersByTime(1500);
+		expect(useLiveModeStore.getState().isRowHighlighted("row-1")).toBe(false);
+		expect(useLiveModeStore.getState().isCellHighlighted("row-1", "title")).toBe(false);
+		vi.useRealTimers();
+	});
+
+	it("resets all state cleanly", () => {
+		useLiveModeStore.getState().setLive(true, "users");
+		useLiveModeStore.getState().setHighlights(["1"], ["1:name"]);
+		useLiveModeStore.getState().reset();
+
+		const state = useLiveModeStore.getState();
+		expect(state.isLive).toBe(false);
+		expect(state.status).toBe("idle");
+		expect(state.activeTable).toBeNull();
+		expect(state.highlightedRowIds.size).toBe(0);
+	});
+});

--- a/packages/web/src/features/tables/stores/live-mode.store.ts
+++ b/packages/web/src/features/tables/stores/live-mode.store.ts
@@ -1,0 +1,134 @@
+import { create } from "zustand";
+
+export type LiveModeStatus = "idle" | "healthy" | "disconnected" | "paused";
+
+interface LiveModeStore {
+	isLive: boolean;
+	status: LiveModeStatus;
+	isPulsing: boolean;
+	activeTable: string | null;
+	highlightedRowIds: Set<string>;
+	highlightedCellKeys: Set<string>;
+
+	setLive: (isLive: boolean, tableName?: string) => void;
+	pauseLive: () => void;
+	setStatus: (status: LiveModeStatus) => void;
+	triggerPulse: () => void;
+	setHighlights: (rowIds: string[], cellKeys: string[], durationMs?: number) => void;
+	clearHighlights: () => void;
+	isRowHighlighted: (rowId: string) => boolean;
+	isCellHighlighted: (rowId: string, columnId: string) => boolean;
+	reset: () => void;
+}
+
+let pulseTimer: ReturnType<typeof setTimeout> | null = null;
+let highlightTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const useLiveModeStore = create<LiveModeStore>()((set, get) => ({
+	isLive: false,
+	status: "idle",
+	isPulsing: false,
+	activeTable: null,
+	highlightedRowIds: new Set(),
+	highlightedCellKeys: new Set(),
+
+	setLive: (isLive, tableName) => {
+		if (!isLive) {
+			set({
+				isLive: false,
+				status: "idle",
+				isPulsing: false,
+			});
+		} else {
+			set({
+				isLive: true,
+				status: "healthy",
+				activeTable: tableName ?? get().activeTable,
+			});
+		}
+	},
+
+	pauseLive: () => {
+		set({
+			isLive: false,
+			status: "paused",
+			isPulsing: false,
+		});
+	},
+
+	setStatus: (status) => {
+		set({ status });
+	},
+
+	triggerPulse: () => {
+		if (pulseTimer) {
+			clearTimeout(pulseTimer);
+		}
+		set({ isPulsing: true });
+		pulseTimer = setTimeout(() => {
+			set({ isPulsing: false });
+			pulseTimer = null;
+		}, 800);
+	},
+
+	setHighlights: (rowIds, cellKeys, durationMs = 1500) => {
+		if (highlightTimer) {
+			clearTimeout(highlightTimer);
+		}
+
+		if (rowIds.length === 0 && cellKeys.length === 0) {
+			return;
+		}
+
+		set({
+			highlightedRowIds: new Set(rowIds),
+			highlightedCellKeys: new Set(cellKeys),
+		});
+
+		highlightTimer = setTimeout(() => {
+			set({
+				highlightedRowIds: new Set(),
+				highlightedCellKeys: new Set(),
+			});
+			highlightTimer = null;
+		}, durationMs);
+	},
+
+	clearHighlights: () => {
+		if (highlightTimer) {
+			clearTimeout(highlightTimer);
+			highlightTimer = null;
+		}
+		set({
+			highlightedRowIds: new Set(),
+			highlightedCellKeys: new Set(),
+		});
+	},
+
+	isRowHighlighted: (rowId) => {
+		return get().highlightedRowIds.has(rowId);
+	},
+
+	isCellHighlighted: (rowId, columnId) => {
+		return get().highlightedCellKeys.has(`${rowId}:${columnId}`);
+	},
+
+	reset: () => {
+		if (pulseTimer) {
+			clearTimeout(pulseTimer);
+			pulseTimer = null;
+		}
+		if (highlightTimer) {
+			clearTimeout(highlightTimer);
+			highlightTimer = null;
+		}
+		set({
+			isLive: false,
+			status: "idle",
+			isPulsing: false,
+			activeTable: null,
+			highlightedRowIds: new Set(),
+			highlightedCellKeys: new Set(),
+		});
+	},
+}));

--- a/packages/web/src/features/tables/stores/live-mode.store.ts
+++ b/packages/web/src/features/tables/stores/live-mode.store.ts
@@ -72,12 +72,13 @@ export const useLiveModeStore = create<LiveModeStore>()((set, get) => ({
 	},
 
 	setHighlights: (rowIds, cellKeys, durationMs = 1500) => {
-		if (highlightTimer) {
-			clearTimeout(highlightTimer);
+		if (rowIds.length === 0 && cellKeys.length === 0) {
+			get().clearHighlights();
+			return;
 		}
 
-		if (rowIds.length === 0 && cellKeys.length === 0) {
-			return;
+		if (highlightTimer) {
+			clearTimeout(highlightTimer);
 		}
 
 		set({

--- a/packages/web/src/features/tables/utils/table-diff.test.ts
+++ b/packages/web/src/features/tables/utils/table-diff.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { diffTableRows, getRecordKey } from "./table-diff";
+
+describe("getRecordKey", () => {
+	it("uses primary key columns when provided", () => {
+		const row = { id: 1, email: "alice@example.com", name: "Alice" };
+		expect(getRecordKey(row, ["email"])).toBe("alice@example.com");
+	});
+
+	it("supports composite primary keys", () => {
+		const row = { orgId: "org-1", userId: "usr-2", role: "admin" };
+		expect(getRecordKey(row, ["orgId", "userId"])).toBe("org-1::usr-2");
+	});
+
+	it("falls back to id when no primary key is specified", () => {
+		const row = { id: 42, title: "Item" };
+		expect(getRecordKey(row)).toBe("42");
+	});
+
+	it("falls back to _id when id is absent", () => {
+		const row = { _id: "mongo-123", name: "Doc" };
+		expect(getRecordKey(row)).toBe("mongo-123");
+	});
+
+	it("falls back to stableStringify when neither id nor _id is present", () => {
+		const row = { key: "val" };
+		expect(getRecordKey(row)).toBe('{"key":"val"}');
+	});
+});
+
+describe("diffTableRows", () => {
+	it("returns no changes when previous rows are undefined or null", () => {
+		const result = diffTableRows(null, [{ id: 1, name: "Alice" }]);
+		expect(result).toEqual({
+			hasVisibleChanges: false,
+			insertedRowIds: [],
+			changedCellKeys: [],
+		});
+	});
+
+	it("returns no changes when rows are identical", () => {
+		const rows = [
+			{ id: 1, name: "Alice", age: 30 },
+			{ id: 2, name: "Bob", age: 25 },
+		];
+		const result = diffTableRows(rows, rows);
+		expect(result.hasVisibleChanges).toBe(false);
+		expect(result.insertedRowIds).toHaveLength(0);
+		expect(result.changedCellKeys).toHaveLength(0);
+	});
+
+	it("detects newly inserted rows", () => {
+		const prev = [{ id: 1, name: "Alice" }];
+		const next = [
+			{ id: 1, name: "Alice" },
+			{ id: 2, name: "Bob" },
+		];
+		const result = diffTableRows(prev, next);
+		expect(result.hasVisibleChanges).toBe(true);
+		expect(result.insertedRowIds).toEqual(["2"]);
+		expect(result.changedCellKeys).toHaveLength(0);
+	});
+
+	it("detects updated cells in existing rows", () => {
+		const prev = [
+			{ id: 1, name: "Alice", status: "offline" },
+			{ id: 2, name: "Bob", status: "online" },
+		];
+		const next = [
+			{ id: 1, name: "Alice", status: "online" },
+			{ id: 2, name: "Bob", status: "online" },
+		];
+		const result = diffTableRows(prev, next);
+		expect(result.hasVisibleChanges).toBe(true);
+		expect(result.insertedRowIds).toHaveLength(0);
+		expect(result.changedCellKeys).toEqual(["1:status"]);
+	});
+
+	it("detects deleted rows", () => {
+		const prev = [
+			{ id: 1, name: "Alice" },
+			{ id: 2, name: "Bob" },
+		];
+		const next = [{ id: 1, name: "Alice" }];
+		const result = diffTableRows(prev, next);
+		expect(result.hasVisibleChanges).toBe(true);
+		expect(result.insertedRowIds).toHaveLength(0);
+	});
+
+	it("detects reordered rows", () => {
+		const prev = [
+			{ id: 1, name: "Alice" },
+			{ id: 2, name: "Bob" },
+		];
+		const next = [
+			{ id: 2, name: "Bob" },
+			{ id: 1, name: "Alice" },
+		];
+		const result = diffTableRows(prev, next);
+		expect(result.hasVisibleChanges).toBe(true);
+	});
+
+	it("handles composite primary keys accurately", () => {
+		const pk = ["dept", "empId"];
+		const prev = [{ dept: "eng", empId: 10, title: "Junior" }];
+		const next = [
+			{ dept: "eng", empId: 10, title: "Senior" },
+			{ dept: "sales", empId: 20, title: "Lead" },
+		];
+		const result = diffTableRows(prev, next, pk);
+		expect(result.hasVisibleChanges).toBe(true);
+		expect(result.insertedRowIds).toEqual(["sales::20"]);
+		expect(result.changedCellKeys).toEqual(["eng::10:title"]);
+	});
+});

--- a/packages/web/src/features/tables/utils/table-diff.test.ts
+++ b/packages/web/src/features/tables/utils/table-diff.test.ts
@@ -9,7 +9,17 @@ describe("getRecordKey", () => {
 
 	it("supports composite primary keys", () => {
 		const row = { orgId: "org-1", userId: "usr-2", role: "admin" };
-		expect(getRecordKey(row, ["orgId", "userId"])).toBe("org-1::usr-2");
+		expect(getRecordKey(row, ["orgId", "userId"])).toBe('["org-1","usr-2"]');
+	});
+
+	it("distinguishes composite keys containing delimiter characters", () => {
+		const rowA = { part1: "a::b", part2: "c" };
+		const rowB = { part1: "a", part2: "b::c" };
+		expect(getRecordKey(rowA, ["part1", "part2"])).not.toBe(
+			getRecordKey(rowB, ["part1", "part2"]),
+		);
+		expect(getRecordKey(rowA, ["part1", "part2"])).toBe('["a::b","c"]');
+		expect(getRecordKey(rowB, ["part1", "part2"])).toBe('["a","b::c"]');
 	});
 
 	it("falls back to id when no primary key is specified", () => {
@@ -109,7 +119,7 @@ describe("diffTableRows", () => {
 		];
 		const result = diffTableRows(prev, next, pk);
 		expect(result.hasVisibleChanges).toBe(true);
-		expect(result.insertedRowIds).toEqual(["sales::20"]);
-		expect(result.changedCellKeys).toEqual(["eng::10:title"]);
+		expect(result.insertedRowIds).toEqual(['["sales",20]']);
+		expect(result.changedCellKeys).toEqual(['["eng",10]:title']);
 	});
 });

--- a/packages/web/src/features/tables/utils/table-diff.ts
+++ b/packages/web/src/features/tables/utils/table-diff.ts
@@ -13,8 +13,11 @@ export const stableStringify = (value: unknown): string => {
 };
 
 export const getRecordKey = (row: TableRecord, primaryKeyCols: string[] = []): string => {
-	if (primaryKeyCols.length > 0) {
-		return primaryKeyCols.map((col) => String(row[col] ?? "")).join("::");
+	if (primaryKeyCols.length === 1) {
+		return String(row[primaryKeyCols[0]] ?? "");
+	}
+	if (primaryKeyCols.length > 1) {
+		return stableStringify(primaryKeyCols.map((col) => row[col]));
 	}
 	if (row.id !== undefined && row.id !== null) return String(row.id);
 	if (row._id !== undefined && row._id !== null) return String(row._id);

--- a/packages/web/src/features/tables/utils/table-diff.ts
+++ b/packages/web/src/features/tables/utils/table-diff.ts
@@ -1,0 +1,102 @@
+import type { TableRecord } from "@/types/table.type";
+
+export const stableStringify = (value: unknown): string => {
+	if (value === undefined) return "undefined";
+	if (value === null || typeof value !== "object") return JSON.stringify(value);
+	if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+
+	const record = value as Record<string, unknown>;
+	return `{${Object.keys(record)
+		.sort()
+		.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+		.join(",")}}`;
+};
+
+export const getRecordKey = (row: TableRecord, primaryKeyCols: string[] = []): string => {
+	if (primaryKeyCols.length > 0) {
+		return primaryKeyCols.map((col) => String(row[col] ?? "")).join("::");
+	}
+	if (row.id !== undefined && row.id !== null) return String(row.id);
+	if (row._id !== undefined && row._id !== null) return String(row._id);
+	return stableStringify(row);
+};
+
+export const isValueEqual = (a: unknown, b: unknown): boolean => {
+	if (a === b) return true;
+	if (typeof a === "object" && typeof b === "object" && a !== null && b !== null) {
+		return stableStringify(a) === stableStringify(b);
+	}
+	return false;
+};
+
+export interface TableDiffResult {
+	hasVisibleChanges: boolean;
+	insertedRowIds: string[];
+	changedCellKeys: string[];
+}
+
+export const diffTableRows = (
+	prevRows: TableRecord[] | null | undefined,
+	nextRows: TableRecord[] | null | undefined,
+	primaryKeyCols: string[] = [],
+): TableDiffResult => {
+	if (!prevRows || !nextRows) {
+		return {
+			hasVisibleChanges: false,
+			insertedRowIds: [],
+			changedCellKeys: [],
+		};
+	}
+
+	const prevKeys = prevRows.map((r) => getRecordKey(r, primaryKeyCols));
+	const nextKeys = nextRows.map((r) => getRecordKey(r, primaryKeyCols));
+
+	let hasVisibleChanges = false;
+
+	if (prevRows.length !== nextRows.length) {
+		hasVisibleChanges = true;
+	} else if (prevKeys.some((k, i) => k !== nextKeys[i])) {
+		hasVisibleChanges = true;
+	}
+
+	const prevMap = new Map<string, TableRecord>();
+	for (let i = 0; i < prevRows.length; i++) {
+		prevMap.set(prevKeys[i], prevRows[i]);
+	}
+
+	const nextKeySet = new Set(nextKeys);
+	const insertedRowIds: string[] = [];
+	const changedCellKeys: string[] = [];
+
+	for (let i = 0; i < nextRows.length; i++) {
+		const key = nextKeys[i];
+		const nextRow = nextRows[i];
+		const prevRow = prevMap.get(key);
+
+		if (!prevRow) {
+			insertedRowIds.push(key);
+			hasVisibleChanges = true;
+		} else {
+			const allCols = new Set([...Object.keys(prevRow), ...Object.keys(nextRow)]);
+			for (const col of allCols) {
+				if (!isValueEqual(prevRow[col], nextRow[col])) {
+					changedCellKeys.push(`${key}:${col}`);
+					hasVisibleChanges = true;
+				}
+			}
+		}
+	}
+
+	for (const prevKey of prevKeys) {
+		if (!nextKeySet.has(prevKey)) {
+			hasVisibleChanges = true;
+			break;
+		}
+	}
+
+	return {
+		hasVisibleChanges,
+		insertedRowIds,
+		changedCellKeys,
+	};
+};

--- a/packages/web/src/hooks/use-database-capabilities.test.ts
+++ b/packages/web/src/hooks/use-database-capabilities.test.ts
@@ -1,0 +1,52 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useDatabaseStore } from "@/stores/database.store";
+import { useDatabaseCapability } from "./use-database-capabilities";
+
+describe("useDatabaseCapability", () => {
+	beforeEach(() => {
+		useDatabaseStore.setState({ dbType: null });
+	});
+
+	it("returns true for liveMode when dbType is pg", () => {
+		useDatabaseStore.setState({ dbType: "pg" });
+		const { result } = renderHook(() => useDatabaseCapability("liveMode"));
+		expect(result.current).toBe(true);
+	});
+
+	it("returns false for liveMode when dbType is mysql", () => {
+		useDatabaseStore.setState({ dbType: "mysql" });
+		const { result } = renderHook(() => useDatabaseCapability("liveMode"));
+		expect(result.current).toBe(false);
+	});
+
+	it("returns false for liveMode when dbType is mssql", () => {
+		useDatabaseStore.setState({ dbType: "mssql" });
+		const { result } = renderHook(() => useDatabaseCapability("liveMode"));
+		expect(result.current).toBe(false);
+	});
+
+	it("returns false for liveMode when dbType is sqlite", () => {
+		useDatabaseStore.setState({ dbType: "sqlite" });
+		const { result } = renderHook(() => useDatabaseCapability("liveMode"));
+		expect(result.current).toBe(false);
+	});
+
+	it("returns false for liveMode when dbType is mongodb", () => {
+		useDatabaseStore.setState({ dbType: "mongodb" });
+		const { result } = renderHook(() => useDatabaseCapability("liveMode"));
+		expect(result.current).toBe(false);
+	});
+
+	it("returns false for liveMode when dbType is redis", () => {
+		useDatabaseStore.setState({ dbType: "redis" });
+		const { result } = renderHook(() => useDatabaseCapability("liveMode"));
+		expect(result.current).toBe(false);
+	});
+
+	it("returns false for liveMode when dbType is null", () => {
+		useDatabaseStore.setState({ dbType: null });
+		const { result } = renderHook(() => useDatabaseCapability("liveMode"));
+		expect(result.current).toBe(false);
+	});
+});

--- a/packages/web/src/hooks/use-database-capabilities.ts
+++ b/packages/web/src/hooks/use-database-capabilities.ts
@@ -1,0 +1,7 @@
+import { type DatabaseCapability, hasDatabaseCapability } from "@db-studio/shared/types";
+import { useDatabaseStore } from "@/stores/database.store";
+
+export const useDatabaseCapability = (capability: DatabaseCapability): boolean => {
+	const dbType = useDatabaseStore((state) => state.dbType);
+	return hasDatabaseCapability(dbType, capability);
+};

--- a/packages/web/src/types/table.type.ts
+++ b/packages/web/src/types/table.type.ts
@@ -63,5 +63,7 @@ declare module "@tanstack/react-table" {
 			direction?: NavigationDirection;
 			moveToNextRow?: boolean;
 		}) => void;
+		isRowHighlighted?: (rowId: string) => boolean;
+		isCellHighlighted?: (rowId: string, columnId: string) => boolean;
 	}
 }


### PR DESCRIPTION
Closes #270

Table data gets stale when records change from another client, forcing users to click Refresh manually. This adds a labeled Live toggle next to the Refresh button for PostgreSQL tables.

When enabled, it refetches the current table query every second while keeping active filters, sorting, cursor pagination, and database context intact. New, updated, or removed rows update directly in the grid, and the indicator dot pulses green with a brief highlight on changed cells and rows.

Polling pauses automatically when you start editing a cell or have an open record sheet, and stays paused until you toggle Live back on. It also suspends while the browser tab is hidden and resumes immediately when the tab is visible again. Background network errors switch the dot to a disconnected state so it doesn't fire repetitive toast alerts.

Tested with `bun run test` (all 1,039 monorepo tests and 140 web tests pass), `bun run typecheck`, and `bun run build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Live Mode for PostgreSQL tables with one-second updates while active.
  - Added status indicators for healthy, paused, and disconnected states.
  - Added visual highlighting and pulse effects for newly changed rows and cells.
  - Live Mode pauses during editing, record viewing, or hidden tabs.
  - Added capability checks so Live Mode appears only for supported databases.

- **Bug Fixes**
  - Prevented stale refresh results from overwriting current table status.
  - Improved table loading behavior during transient refresh errors.

- **Tests**
  - Added coverage for Live Mode, polling, highlighting, database support, and state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->