### PR TITLE
fix(back): list all six databases in help and keep error text intact

### DIFF
--- a/packages/server/src/cmd/sanitize-error.ts
+++ b/packages/server/src/cmd/sanitize-error.ts
@@ -1,0 +1,11 @@
+/**
+ * Redact database connection URLs from error text before printing them.
+ * Only the URL itself is replaced; surrounding prose and punctuation
+ * (closing parens, commas) are left intact.
+ */
+export const sanitizeErrorMessage = (message: string): string => {
+	return message.replace(
+		/\b(?:postgres(?:ql)?|mysql2?|mssql|sqlserver|mongodb(?:\+srv)?|sqlite|rediss?):\/\/[^\s),]*/gi,
+		"the configured database",
+	);
+};

--- a/packages/server/src/cmd/show-help.ts
+++ b/packages/server/src/cmd/show-help.ts
@@ -12,7 +12,7 @@ export const showHelp = () => {
 	console.log("  db-studio [options]\n");
 
 	console.log(color.bold("Supported Databases:"));
-	console.log("  MySQL, PostgreSQL\n");
+	console.log("  PostgreSQL, MySQL, SQL Server, MongoDB, SQLite, Redis\n");
 
 	console.log(color.bold("Options:"));
 	console.log("  -e, --env <path>         Path to custom .env file");

--- a/packages/server/src/cmd/show-status.ts
+++ b/packages/server/src/cmd/show-status.ts
@@ -30,7 +30,11 @@ export const showStatus = async (env?: string, databaseUrl?: string, varName?: s
 	} else {
 		note(color.red(`✗ ${envVarName} not found`), "Status");
 		console.log(color.yellow("\n  To configure database connection:"));
-		console.log(color.dim("  • Supported databases: MySQL, PostgreSQL"));
+		console.log(
+			color.dim(
+				"  • Supported databases: PostgreSQL, MySQL, SQL Server, MongoDB, SQLite, Redis",
+			),
+		);
 		console.log(color.dim(`  • Add ${envVarName} to your .env file or set it in process.env`));
 		console.log(color.dim("  • Use -d flag: db-studio -d <url>"));
 		console.log(color.dim("  • Use -e flag: db-studio -e <path-to-env>"));

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ import { args } from "@/cmd/args.js";
 import { getDatabaseUrl } from "@/cmd/get-db-url.js";
 import { loadEnv } from "@/cmd/load-env.js";
 import { openBrowser, shouldOpenBrowser } from "@/cmd/open-browser.js";
+import { sanitizeErrorMessage } from "@/cmd/sanitize-error.js";
 import { showHelp } from "@/cmd/show-help.js";
 import { showStatus } from "@/cmd/show-status.js";
 import { showVersion } from "@/cmd/show-version.js";
@@ -109,11 +110,7 @@ export const main = async () => {
 if (process.env.NODE_ENV !== "test") {
 	main().catch((error: unknown) => {
 		const message = error instanceof Error ? error.message : String(error);
-		const sanitizedMessage = message.replace(
-			/\b(?:postgres(?:ql)?|mysql2?|mssql|sqlserver|mongodb(?:\+srv)?|sqlite|rediss?):\/\/\S+/gi,
-			"the configured database",
-		);
-		outro(color.red(`Startup failed: ${sanitizedMessage}`));
+		outro(color.red(`Startup failed: ${sanitizeErrorMessage(message)}`));
 		process.exit(1);
 	});
 }

--- a/packages/server/tests/cmd/sanitize-error.test.ts
+++ b/packages/server/tests/cmd/sanitize-error.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeErrorMessage } from "@/cmd/sanitize-error.js";
+
+describe("sanitizeErrorMessage", () => {
+	it("redacts a bare connection URL", () => {
+		expect(sanitizeErrorMessage("connect ECONNREFUSED postgresql://admin:secret@localhost:5432/app")).toBe(
+			"connect ECONNREFUSED the configured database",
+		);
+	});
+
+	it("keeps closing parens and commas of the supported-types message", () => {
+		expect(
+			sanitizeErrorMessage(
+				"Unsupported database type: invalid. Supported types: PostgreSQL (postgres://), MySQL (mysql://), SQL Server (mssql://).",
+			),
+		).toBe(
+			"Unsupported database type: invalid. Supported types: PostgreSQL (the configured database), MySQL (the configured database), SQL Server (the configured database).",
+		);
+	});
+
+	it("leaves text without a URL untouched", () => {
+		expect(sanitizeErrorMessage("Database startup check timed out")).toBe(
+			"Database startup check timed out",
+		);
+	});
+});


### PR DESCRIPTION
--help and --status still said MySQL, PostgreSQL even though four more engines shipped. I updated both to list all six. The startup error scrubber also ate closing parens, so the supported-types hint came out garbled. I moved it into a small helper that only redacts the URL itself.

Ran bunx vitest run in packages/server, all 1042 tests pass. I've added tests/cmd/sanitize-error.test.ts with 3 cases.

Closes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded supported database guidance in help and status messages to include PostgreSQL, MySQL, SQL Server, MongoDB, SQLite, and Redis.

* **Bug Fixes**
  * Improved startup error sanitization to redact complete database connection URLs, including credentials and hosts containing commas or parentheses, while preserving surrounding punctuation and text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->