### PR TITLE
fix(turbo): use real script names in task graph and order server after web

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,21 @@
         "SENTRY_AUTH_TOKEN"
       ]
     },
+    "db-studio#build": {
+      "dependsOn": [
+        "@db-studio/web#build",
+        "^build"
+      ],
+      "outputs": [
+        "dist/**"
+      ],
+      "env": [
+        "NODE_ENV"
+      ],
+      "passThroughEnv": [
+        "SENTRY_AUTH_TOKEN"
+      ]
+    },
     "@db-studio/shared#build": {
       "outputs": [],
       "cache": true
@@ -25,57 +40,14 @@
       "outputs": [],
       "cache": true
     },
-    "build:web": {
-      "outputs": [
-        "dist/**"
-      ],
-      "cache": true
-    },
-    "build:server": {
-      "dependsOn": [
-        "build:web"
-      ],
-      "outputs": [
-        "dist/**"
-      ],
-      "cache": true
-    },
-    "build:proxy": {
-      "outputs": [
-        "dist/**"
-      ],
-      "cache": true
-    },
-    "build:www": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "dist/**",
-        ".vercel/**"
-      ],
-      "cache": true
-    },
     "dev": {
       "cache": false,
       "persistent": true
     },
-    "dev:web": {
-      "cache": false,
-      "persistent": true
-    },
-    "dev:server": {
+    "db-studio#dev": {
       "dependsOn": [
-        "build:web"
+        "@db-studio/web#build"
       ],
-      "cache": false,
-      "persistent": true
-    },
-    "dev:proxy": {
-      "cache": false,
-      "persistent": true
-    },
-    "dev:www": {
       "cache": false,
       "persistent": true
     },
@@ -94,9 +66,23 @@
       "dependsOn": [
         "^build"
       ],
+      "outputs": [],
+      "cache": true
+    },
+    "db-studio#test": {
+      "dependsOn": [
+        "^build"
+      ],
       "outputs": [
         "coverage/**"
       ],
+      "cache": true
+    },
+    "@db-studio/web#test": {
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [],
       "cache": true
     },
     "deploy": {
@@ -106,23 +92,12 @@
       "cache": false,
       "outputs": []
     },
-    "deploy:www": {
+    "deploy:preview": {
       "dependsOn": [
-        "build:www"
+        "build"
       ],
-      "cache": false
-    },
-    "deploy:www:preview": {
-      "dependsOn": [
-        "build:www"
-      ],
-      "cache": false
-    },
-    "deploy:proxy": {
-      "dependsOn": [
-        "build:proxy"
-      ],
-      "cache": false
+      "cache": false,
+      "outputs": []
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
turbo.json defined colon tasks like build:www that match no workspace script, so dry runs showed NONEXISTENT everywhere and deploys couldn't resolve. I switched the graph to the plain build, dev, deploy, and deploy:preview names each package actually has. Server build now depends on web build too, so building the server alone pulls fresh frontend assets instead of warning about a missing web/dist.

Checked with turbo dry runs for build, typecheck, test, and all three deploy filters, zero NONEXISTENT left. I also wiped both dist dirs and ran bun run build:server, web-dist lands in the bundle. web test no longer warns about missing outputs.

Relates to #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized build, development, testing, and deployment workflows around package-scoped tasks.
  * Added dedicated testing workflows for improved validation.
  * Added support for preview deployments.
  * Removed several app-specific workflow entries as part of the configuration restructure.
  * No direct changes to end-user functionality are included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->