### PR TITLE
fix(shared): drop bogus module entry and dedupe knip entries

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -14,7 +14,7 @@
       "project": ["src/**/*.ts"]
     },
     "packages/shared": {
-      "entry": ["src/index.ts", "src/types/index.ts", "src/constants/index.ts"],
+      "entry": ["src/index.ts"],
       "project": ["src/**/*.ts"]
     },
     "www": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@db-studio/shared",
-  "module": "index.ts",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",


### PR DESCRIPTION
The shared package pointed module at index.ts, a file that doesn't exist, so knip died on Package entry file not found before checking anything. I removed the field since exports already maps every entry correctly. I also deduped the shared entry list in knip.json because src/index.ts just re-exports the other two.

Ran bun run knip, the entry error is gone. Shared still builds with tsc and both export paths resolve from the server package.

Relates to #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal package entry configuration.
  * Updated module resolution to rely on the package’s defined exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->